### PR TITLE
Add tag-driven release/publish CI gated behind PUBLISH_ENABLED

### DIFF
--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -1,0 +1,181 @@
+name: APT/DNF Repo Heartbeat
+
+# Walks the published .deb and .rpm URLs through the full
+# Pages 301 -> Worker 302 -> Releases 302 -> CDN 200 chain daily, asserts
+# ordered hops + a size match against the Releases asset, and opens a tracking
+# issue (format-specific label) on failure, auto-closing it on recovery.
+#
+# The gate step skips gracefully when the production Worker isn't live yet
+# (before the publish layer is enabled), so this is a no-op until releases ship.
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # daily noon UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  ping:
+    strategy:
+      fail-fast: false
+      matrix:
+        format: [deb, rpm]
+    runs-on: ubuntu-latest
+    env:
+      WORKER_DOMAIN: pkg.wispr-flow-linux.dev
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Skip if Worker not live yet
+        id: gate
+        run: |
+          if curl -fsI --max-time 10 \
+              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+            echo "live=true" >> "$GITHUB_OUTPUT"
+            echo "Worker live; running heartbeat."
+          else
+            echo "live=false" >> "$GITHUB_OUTPUT"
+            echo "Worker not live; heartbeat skipping (expected pre-publish)."
+          fi
+
+      - name: Resolve latest release for ${{ matrix.format }}
+        if: steps.gate.outputs.live == 'true'
+        id: latest
+        run: |
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          tag=$(gh release list --limit 1 --json tagName \
+                  --jq '.[0].tagName' -R "$GITHUB_REPOSITORY")
+          repoVer="${tag#v}"; repoVer="${repoVer%+wispr*}"
+          wisprVer="${tag#*+wispr}"
+          if [[ "${{ matrix.format }}" == "deb" ]]; then
+            asset="wispr-flow_${wisprVer}-${repoVer}_amd64.deb"
+            url="https://${owner}.github.io/${repo}/pool/main/w/wispr-flow/${asset}"
+          else
+            asset="wispr-flow-${wisprVer}-${repoVer}-1.x86_64.rpm"
+            url="https://${owner}.github.io/${repo}/rpm/x86_64/${asset}"
+          fi
+          {
+            echo "tag=${tag}"
+            echo "asset=${asset}"
+            echo "url=${url}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate ordered chain + fetch + size match
+        if: steps.gate.outputs.live == 'true'
+        env:
+          ASSET: ${{ steps.latest.outputs.asset }}
+          URL: ${{ steps.latest.outputs.url }}
+          TAG: ${{ steps.latest.outputs.tag }}
+          FORMAT: ${{ matrix.format }}
+        run: |
+          set -euo pipefail
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+
+          deadline=$((SECONDS + 300))
+          until curl -fsI --max-time 10 "$URL" -o /dev/null; do
+            if [[ $SECONDS -gt $deadline ]]; then
+              echo "::error::Reachability timeout for ${URL}"
+              exit 1
+            fi
+            sleep 10
+          done
+
+          expected_hops=(
+            "https?://${WORKER_DOMAIN}/"
+            "https://github\\.com/${owner}/${repo}/releases/download/"
+            "https://(objects|release-assets)\\.githubusercontent\\.com/"
+          )
+          url="$URL"
+          for i in "${!expected_hops[@]}"; do
+            hop_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            redirect_url=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+            echo "Hop ${i}: ${hop_status} ${url} -> ${redirect_url}"
+            if [[ ! "$hop_status" =~ ^30[12]$ ]]; then
+              echo "::error::Hop ${i}: expected 301/302, got ${hop_status}"
+              exit 1
+            fi
+            if [[ ! "$redirect_url" =~ ^${expected_hops[$i]} ]]; then
+              echo "::error::Hop ${i} mismatch:"
+              echo "::error::  expected: ${expected_hops[$i]}"
+              echo "::error::  got:      ${redirect_url}"
+              exit 1
+            fi
+            url="$redirect_url"
+          done
+
+          curl -fsSL -o "/tmp/${ASSET}" "$URL"
+          if [[ "$FORMAT" == "deb" ]]; then
+            if ! file "/tmp/${ASSET}" | grep -q 'Debian binary package'; then
+              echo "::error::Fetched file is not a valid Debian package"
+              exit 1
+            fi
+          else
+            sudo apt-get update >/dev/null
+            sudo apt-get install -y rpm >/dev/null
+            if ! rpm -qpi "/tmp/${ASSET}" >/dev/null 2>&1; then
+              echo "::error::Fetched file is not a valid RPM"
+              exit 1
+            fi
+          fi
+
+          asset_size=$(gh release view "$TAG" -R "$GITHUB_REPOSITORY" \
+            --json assets --jq ".assets[] | select(.name == \"${ASSET}\") | .size")
+          local_size=$(stat -c %s "/tmp/${ASSET}")
+          if [[ "$asset_size" != "$local_size" ]]; then
+            echo "::error::Size mismatch: local ${local_size} vs Releases ${asset_size}"
+            exit 1
+          fi
+          echo "Heartbeat passed: chain validated, file matches Releases asset."
+
+      - name: Open or update failure issue
+        if: failure() && steps.gate.outputs.live == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          FORMAT: ${{ matrix.format }}
+        with:
+          script: |
+            const fmt = process.env.FORMAT;
+            const label = `heartbeat-failure-${fmt}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Heartbeat failed for \`${fmt}\` at ${new Date().toISOString()}.\nRun: ${runUrl}`;
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo, labels: label, state: 'open',
+            });
+            if (open.length === 0) {
+              await github.rest.issues.create({
+                ...context.repo,
+                title: `APT/DNF repo heartbeat failing (${fmt})`,
+                body, labels: [label],
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: open[0].number, body,
+              });
+            }
+
+      - name: Auto-close failure issue on recovery
+        if: success() && steps.gate.outputs.live == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          FORMAT: ${{ matrix.format }}
+        with:
+          script: |
+            const fmt = process.env.FORMAT;
+            const label = `heartbeat-failure-${fmt}`;
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo, labels: label, state: 'open',
+            });
+            for (const issue of open) {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: issue.number,
+                body: `Heartbeat for \`${fmt}\` recovered at ${new Date().toISOString()}; auto-closing.`,
+              });
+              await github.rest.issues.update({
+                ...context.repo, issue_number: issue.number, state: 'closed',
+              });
+            }

--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -1,0 +1,113 @@
+name: Build Package AMD64 (Reusable)
+
+# Builds one package format for x86_64. CI downloads the proprietary Wispr Flow
+# installer (the sensitive action gated by vars.PUBLISH_ENABLED in the caller)
+# and the pinned prebuilt clean-room helper, then runs build.sh. The .exe and
+# helper never live in the repo.
+
+on:
+  workflow_call:
+    inputs:
+      build_flags:
+        description: 'Flags to pass to build.sh (e.g., "--build deb --clean no")'
+        required: false
+        type: string
+        default: ""
+      artifact_suffix:
+        description: "Suffix for the artifact name (deb, rpm, appimage)"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag (e.g., v1.0.0+wispr1.5.695) to derive package version"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ${{ inputs.artifact_suffix == 'rpm' && 'fedora:42' || '' }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install dependencies (Fedora)
+        if: inputs.artifact_suffix == 'rpm'
+        run: |
+          dnf install -y git findutils which curl
+
+      - name: Install FUSE for AppImageTool (Ubuntu)
+        if: inputs.artifact_suffix != 'rpm'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2
+
+      - name: Make scripts executable
+        run: chmod +x ./build.sh scripts/setup/resolve-installer-url.sh scripts/setup/fetch-helper-bin.sh
+
+      - name: Resolve and download Wispr Flow installer
+        run: |
+          scripts/setup/resolve-installer-url.sh > resolved.txt
+          url=$(grep '^URL=' resolved.txt | cut -d= -f2-)
+          [[ -n "$url" ]] || { echo "::error::no installer URL resolved"; exit 1; }
+          echo "Downloading installer: $url"
+          curl -fSL -o wispr-flow-setup.exe "$url"
+
+      - name: Fetch pinned helper binary (x86_64)
+        run: |
+          echo "HELPER_BIN=$(scripts/setup/fetch-helper-bin.sh x86_64)" >> "$GITHUB_ENV"
+
+      - name: Run build script
+        run: |
+          TAG_FLAG=""
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            TAG_FLAG="--release-tag ${{ inputs.release_tag }}"
+          fi
+          # shellcheck disable=SC2086  # build_flags / TAG_FLAG are multi-word
+          # flag strings that MUST word-split into separate argv entries.
+          ./build.sh ${{ inputs.build_flags }} --exe wispr-flow-setup.exe $TAG_FLAG
+
+      - name: Collect built artifacts
+        # build.sh writes outputs under the build-linux/ work dir: deb/ and
+        # appimage/ are shallow, but rpmbuild nests the rpm several levels deep,
+        # so search the whole work tree rather than a fixed maxdepth.
+        run: |
+          mkdir -p out
+          find build-linux \
+            \( -name 'wispr-flow_*.deb' \
+            -o -name 'wispr-flow-*.rpm' \
+            -o -name 'wispr-flow-*.AppImage' \) \
+            -exec cp -v {} out/ \;
+
+      # Static-grep the shipped app.asar for the Linux patch markers. Pinned to
+      # the deb job because the patched JS is identical across formats, so one
+      # verification per CI run is sufficient.
+      - name: Verify Linux patches in shipped asar
+        if: inputs.artifact_suffix == 'deb'
+        run: |
+          deb_file=$(find out -name 'wispr-flow_*_amd64.deb' -print -quit)
+          if [[ -z "$deb_file" ]]; then
+            echo "verify-patches: no .deb artifact found" >&2
+            exit 1
+          fi
+          extract_dir=$(mktemp -d)
+          dpkg-deb -x "$deb_file" "$extract_dir"
+          asar_path=$(find "$extract_dir" -name app.asar -print -quit)
+          if [[ -z "$asar_path" ]]; then
+            echo "verify-patches: app.asar not found in deb" >&2
+            exit 1
+          fi
+          ./scripts/verify-patches.sh "$asar_path"
+
+      - name: Upload AMD64 Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package-amd64-${{ inputs.artifact_suffix }}
+          path: out/*
+          if-no-files-found: error

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -1,0 +1,90 @@
+name: Build Package ARM64 (Reusable)
+
+# Builds one package format for aarch64. Wispr publishes only a Windows x64
+# installer, so this extracts the SAME x64 .exe (the app bundle is arch-neutral
+# JS/asar) and pairs it with the arm64 Electron runtime, arm64-rebuilt native
+# modules, and the aarch64 helper.
+
+on:
+  workflow_call:
+    inputs:
+      build_flags:
+        description: 'Flags to pass to build.sh (e.g., "--build deb --clean no")'
+        required: false
+        type: string
+        default: ""
+      artifact_suffix:
+        description: "Suffix for the artifact name (deb, rpm, appimage)"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag (e.g., v1.0.0+wispr1.5.695) to derive package version"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04-arm
+    container: ${{ inputs.artifact_suffix == 'rpm' && 'fedora:42' || '' }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install dependencies (Fedora)
+        if: inputs.artifact_suffix == 'rpm'
+        run: |
+          dnf install -y git findutils which curl
+
+      - name: Install FUSE for AppImageTool (Ubuntu)
+        if: inputs.artifact_suffix != 'rpm'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libfuse2
+
+      - name: Make scripts executable
+        run: chmod +x ./build.sh scripts/setup/resolve-installer-url.sh scripts/setup/fetch-helper-bin.sh
+
+      - name: Resolve and download Wispr Flow installer
+        run: |
+          scripts/setup/resolve-installer-url.sh > resolved.txt
+          url=$(grep '^URL=' resolved.txt | cut -d= -f2-)
+          [[ -n "$url" ]] || { echo "::error::no installer URL resolved"; exit 1; }
+          echo "Downloading installer: $url"
+          curl -fSL -o wispr-flow-setup.exe "$url"
+
+      - name: Fetch pinned helper binary (aarch64)
+        run: |
+          echo "HELPER_BIN=$(scripts/setup/fetch-helper-bin.sh aarch64)" >> "$GITHUB_ENV"
+
+      - name: Run build script
+        run: |
+          TAG_FLAG=""
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            TAG_FLAG="--release-tag ${{ inputs.release_tag }}"
+          fi
+          # shellcheck disable=SC2086  # build_flags / TAG_FLAG are multi-word
+          # flag strings that MUST word-split into separate argv entries.
+          ./build.sh ${{ inputs.build_flags }} --exe wispr-flow-setup.exe $TAG_FLAG
+
+      - name: Collect built artifacts
+        run: |
+          mkdir -p out
+          find build-linux \
+            \( -name 'wispr-flow_*.deb' \
+            -o -name 'wispr-flow-*.rpm' \
+            -o -name 'wispr-flow-*.AppImage' \) \
+            -exec cp -v {} out/ \;
+
+      - name: Upload ARM64 Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: package-arm64-${{ inputs.artifact_suffix }}
+          path: out/*
+          if-no-files-found: error

--- a/.github/workflows/check-wispr-version.yml
+++ b/.github/workflows/check-wispr-version.yml
@@ -1,0 +1,100 @@
+name: Check Wispr Flow Version
+
+# Tracks upstream Wispr Flow releases. Daily, it resolves the latest Windows
+# installer version from Wispr's "latest" redirect; when it differs from the
+# stored WISPR_FLOW_VERSION it bumps APP_VERSION (build.sh) and the Nix package
+# version, updates the variable, and pushes a v<REPO_VERSION>+wispr<VERSION> tag
+# that triggers the gated publish chain in ci.yml.
+#
+# Gated behind vars.PUBLISH_ENABLED: until Wispr Flow's ToS clears, this stays
+# dormant (no upstream download, no tag). Needs GH_PAT (the default GITHUB_TOKEN
+# cannot push a tag that re-triggers tag-driven workflows).
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: main-branch-auto-update
+  cancel-in-progress: false
+
+jobs:
+  check-version:
+    if: ${{ vars.PUBLISH_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Resolve latest Wispr Flow version
+        id: resolve
+        run: |
+          chmod +x scripts/setup/resolve-installer-url.sh
+          scripts/setup/resolve-installer-url.sh > resolved.txt
+          version=$(grep '^VERSION=' resolved.txt | cut -d= -f2-)
+          [[ -n "$version" ]] || { echo "::error::no version resolved"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved upstream version: $version"
+
+      - name: Check if update needed
+        id: check
+        run: |
+          new="${{ steps.resolve.outputs.version }}"
+          stored="${{ vars.WISPR_FLOW_VERSION }}"
+          repo_ver="${{ vars.REPO_VERSION }}"
+          echo "stored=$stored new=$new repo_ver=$repo_ver"
+          if [[ -z "$repo_ver" ]]; then
+            echo "::error::REPO_VERSION variable is not set"
+            exit 1
+          fi
+          if [[ "$new" == "$stored" ]]; then
+            echo "Up to date; nothing to do."
+            echo "update_needed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "update_needed=true" >> "$GITHUB_OUTPUT"
+            echo "new_tag=v${repo_ver}+wispr${new}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump APP_VERSION and Nix version
+        if: steps.check.outputs.update_needed == 'true'
+        run: |
+          new="${{ steps.resolve.outputs.version }}"
+          # build.sh: the hardcoded upstream version constant.
+          sed -i "s/^readonly APP_VERSION='[^']*'/readonly APP_VERSION='$new'/" build.sh
+          # nix/wispr-flow.nix: only the FIRST `version = "..."` (the app's;
+          # the helper's version line comes later and must NOT be touched).
+          sed -i "0,/version = \"[^\"]*\";/ s//version = \"$new\";/" nix/wispr-flow.nix
+          echo "--- build.sh ---"; grep "APP_VERSION='" build.sh
+          echo "--- nix ---"; grep -n 'version = "' nix/wispr-flow.nix
+
+      - name: Commit, set variable, and push tag
+        if: steps.check.outputs.update_needed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          new="${{ steps.resolve.outputs.version }}"
+          new_tag="${{ steps.check.outputs.new_tag }}"
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::GH_PAT secret is not configured"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet build.sh nix/wispr-flow.nix; then
+            echo "No file changes (version constants already current)."
+          else
+            git add build.sh nix/wispr-flow.nix
+            git commit -m "chore: bump Wispr Flow to ${new}"
+            git push
+          fi
+          gh variable set WISPR_FLOW_VERSION --body "$new"
+          echo "Creating and pushing tag: $new_tag"
+          git tag -a "$new_tag" -m "Wispr Flow ${new}"
+          git push origin "$new_tag"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ run-name: |
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -22,6 +23,8 @@ permissions:
 
 jobs:
   # --- Gates (lint + unit tests + flag parsing) ----------------------------
+  # These run on every push/PR (including tag pushes) and gate the publish
+  # chain below.
   test-flags:
     name: Test Flags Parsing
     uses: ./.github/workflows/test-flags.yml
@@ -38,7 +41,573 @@ jobs:
     name: BATS Tests
     uses: ./.github/workflows/tests.yml
 
-  # NOTE: This repo intentionally ships no package-build, release, or publish
-  # CI. Packaging is local-only: a user builds a `.deb`/`.rpm`/AppImage on
-  # their own machine from a Wispr Flow installer they obtained themselves
-  # (see build.sh and scripts/packaging/).
+  # --- Gated publish chain --------------------------------------------------
+  # Everything below downloads the proprietary Wispr Flow installer and/or
+  # publishes binaries. It runs ONLY on a `v*` tag AND only when the repo
+  # variable PUBLISH_ENABLED is 'true' (held off pending Wispr Flow's ToS --
+  # see RELEASING.md). With PUBLISH_ENABLED unset, a tag push runs just the
+  # gate jobs above; flipping it to 'true' activates the whole pipeline with
+  # no code change.
+
+  build-amd64:
+    name: Build AMD64
+    needs: [test-flags, shellcheck, codespell, tests]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        suffix: [deb, rpm, appimage]
+    uses: ./.github/workflows/build-amd64.yml
+    with:
+      build_flags: "--build ${{ matrix.suffix }} --clean no"
+      artifact_suffix: ${{ matrix.suffix }}
+      release_tag: ${{ github.ref_name }}
+
+  build-arm64:
+    name: Build ARM64
+    needs: [test-flags, shellcheck, codespell, tests]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        suffix: [deb, rpm, appimage]
+    uses: ./.github/workflows/build-arm64.yml
+    with:
+      build_flags: "--build ${{ matrix.suffix }} --clean no"
+      artifact_suffix: ${{ matrix.suffix }}
+      release_tag: ${{ github.ref_name }}
+
+  test-artifacts:
+    name: Test Artifacts
+    needs: [build-amd64]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    uses: ./.github/workflows/test-artifacts.yml
+
+  release:
+    name: Create Release
+    needs: [build-amd64, build-arm64, test-artifacts]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository (for git history)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Generate release notes
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          wispr_ver="${tag#*+wispr}"
+          mkdir -p notes
+
+          # Previous release tag (most recent that isn't the current one).
+          prev_tag=$(gh release list --limit 20 -R "$GITHUB_REPOSITORY" \
+            --json tagName -q '.[].tagName' \
+            | grep -v "^${tag}$" | head -1 || true)
+
+          {
+            echo "## Wispr Flow for Linux ${tag}"
+            echo ""
+            echo "Unofficial Linux packages bundling Wispr Flow **${wispr_ver}**."
+            echo ""
+            if [[ -n "$prev_tag" ]]; then
+              echo "### Changes since ${prev_tag}"
+              echo ""
+              git log "${prev_tag}..${tag}" \
+                --pretty=format:"- %s (%h)" --no-merges || true
+              echo ""
+            fi
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Installation"
+            echo ""
+            echo "### APT (Debian/Ubuntu)"
+            echo '```bash'
+            echo "curl -fsSL https://pkg.wispr-flow-linux.dev/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/wispr-flow.gpg"
+            echo 'echo "deb [signed-by=/usr/share/keyrings/wispr-flow.gpg arch=amd64,arm64] https://pkg.wispr-flow-linux.dev stable main" | sudo tee /etc/apt/sources.list.d/wispr-flow.list'
+            echo "sudo apt update && sudo apt install wispr-flow"
+            echo '```'
+            echo ""
+            echo "### DNF (Fedora/RHEL)"
+            echo '```bash'
+            echo "sudo curl -fsSL https://pkg.wispr-flow-linux.dev/rpm/wispr-flow.repo -o /etc/yum.repos.d/wispr-flow.repo"
+            echo "sudo dnf install wispr-flow"
+            echo '```'
+            echo ""
+            echo "### AUR (Arch Linux)"
+            echo '```bash'
+            echo "yay -S wispr-flow-appimage"
+            echo '```'
+            echo ""
+            echo "### Manual download"
+            echo ""
+            echo "Grab a \`.deb\`, \`.rpm\`, or \`.AppImage\` from the assets below."
+            echo ""
+            echo "> These packages bundle the proprietary Wispr Flow app, downloaded from"
+            echo "> Wispr's official endpoint at build time. Wispr Flow is a trademark of"
+            echo "> its owners; this is an unofficial community port."
+          } > notes/summary.md
+
+          echo "--- release notes ---"
+          cat notes/summary.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          files: artifacts/**/*
+          body_path: notes/summary.md
+
+  update-apt-repo:
+    name: Update APT Repository
+    needs: [release]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      WORKER_DOMAIN: pkg.wispr-flow-linux.dev
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: gh-pages
+          path: apt-repo
+
+      - name: Download AMD64 deb artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package-amd64-deb
+          path: incoming/
+
+      - name: Download ARM64 deb artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package-arm64-deb
+          path: incoming/
+
+      - name: Install reprepro
+        run: sudo apt-get update && sudo apt-get install -y reprepro
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
+        with:
+          gpg_private_key: ${{ secrets.REPO_GPG_PRIVATE_KEY }}
+
+      - name: Publish KEY.gpg with all public keys from keyring
+        working-directory: apt-repo
+        run: |
+          gpg --armor --export > KEY.gpg
+          echo "Keys published in KEY.gpg:"
+          gpg --show-keys < KEY.gpg
+
+      - name: Add packages to repository
+        working-directory: apt-repo
+        run: |
+          # Remove existing versions first so re-uploads / wrapper bumps don't
+          # collide (reprepro rejects same-name files with different checksums).
+          for deb in ../incoming/*.deb; do
+            pkg_name=$(dpkg-deb -f "$deb" Package)
+            if reprepro list stable "$pkg_name" 2>/dev/null | grep -q .; then
+              echo "Removing existing $pkg_name from repository..."
+              reprepro remove stable "$pkg_name"
+            fi
+          done
+          for deb in ../incoming/*.deb; do
+            echo "Adding $deb to repository..."
+            reprepro --section utils --priority optional includedeb stable "$deb"
+          done
+
+      - name: Strip binaries from pool (gated on Worker liveness)
+        working-directory: apt-repo
+        run: |
+          # When the Worker is live it 302-redirects /pool/.../*.deb to the
+          # GitHub Release asset, so the binaries are stripped from gh-pages
+          # (metadata still references the pool path; the Worker intercepts).
+          # When it isn't live, keep the .debs so fetches don't 404.
+          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
+          if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
+            echo "Worker live at ${WORKER_DOMAIN}; stripping binaries from pool"
+            find pool -type f -name '*.deb' -delete
+          else
+            echo "Worker not responding at ${WORKER_DOMAIN}; preserving .debs in pool"
+          fi
+
+      - name: Commit and push changes
+        working-directory: apt-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "Update APT repository for ${{ github.ref_name }}"
+          for i in 1 2 3 4 5; do
+            git pull --rebase && git push && break
+            if [[ $i -eq 5 ]]; then
+              echo "::error::Failed to push APT repo after 5 attempts"
+              exit 1
+            fi
+            wait_time=$((2 ** i))
+            echo "Push failed, retrying in ${wait_time}s... (attempt $i/5)"
+            sleep "$wait_time"
+          done
+
+      - name: Smoke test published deb (ordered chain + size)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! curl -fsI --max-time 10 \
+              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+            echo "Worker not live; skipping smoke test"
+            exit 0
+          fi
+          repoVer="${TAG#v}"; repoVer="${repoVer%+wispr*}"
+          wisprVer="${TAG#*+wispr}"
+          deb_name="wispr-flow_${wisprVer}-${repoVer}_amd64.deb"
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          deb_url="https://${owner}.github.io/${repo}/pool/main/w/wispr-flow/${deb_name}"
+
+          deadline=$((SECONDS + 300))
+          until curl -fsI --max-time 10 "$deb_url" -o /dev/null; do
+            [[ $SECONDS -gt $deadline ]] \
+              && { echo "::error::Reachability timeout for ${deb_url}"; exit 1; }
+            sleep 10
+          done
+
+          expected_hops=(
+            "https?://${WORKER_DOMAIN}/"
+            "https://github\\.com/${owner}/${repo}/releases/download/v${repoVer}\\+wispr${wisprVer}/"
+            "https://(objects|release-assets)\\.githubusercontent\\.com/"
+          )
+          url="$deb_url"
+          for i in "${!expected_hops[@]}"; do
+            hop_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            redirect_url=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+            echo "Hop ${i}: ${hop_status} ${url} -> ${redirect_url}"
+            [[ "$hop_status" =~ ^30[12]$ ]] \
+              || { echo "::error::Hop ${i} expected 301/302, got ${hop_status}"; exit 1; }
+            [[ "$redirect_url" =~ ^${expected_hops[$i]} ]] \
+              || { echo "::error::Hop ${i} mismatch: expected ${expected_hops[$i]}, got ${redirect_url}"; exit 1; }
+            url="$redirect_url"
+          done
+
+          curl -fsSL -o /tmp/smoke.deb "$deb_url"
+          file /tmp/smoke.deb | grep -q 'Debian binary package' \
+            || { echo "::error::Not a valid Debian package"; exit 1; }
+          asset_size=$(gh release view "$TAG" -R "$GITHUB_REPOSITORY" \
+            --json assets --jq ".assets[] | select(.name == \"${deb_name}\") | .size")
+          local_size=$(stat -c %s /tmp/smoke.deb)
+          [[ "$asset_size" == "$local_size" ]] \
+            || { echo "::error::Size mismatch: ${local_size} vs ${asset_size}"; exit 1; }
+          echo "APT smoke test passed."
+
+  update-dnf-repo:
+    name: Update DNF Repository
+    needs: [release, update-apt-repo]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      WORKER_DOMAIN: pkg.wispr-flow-linux.dev
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: gh-pages
+          path: dnf-repo
+
+      - name: Download AMD64 rpm artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package-amd64-rpm
+          path: incoming/
+
+      - name: Download ARM64 rpm artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package-arm64-rpm
+          path: incoming/
+
+      - name: Install createrepo_c and rpm-sign
+        run: sudo apt-get update && sudo apt-get install -y createrepo-c rpm
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
+        with:
+          gpg_private_key: ${{ secrets.REPO_GPG_PRIVATE_KEY }}
+
+      - name: Configure RPM signing
+        run: |
+          cat > ~/.rpmmacros << EOF
+          %_signature gpg
+          %_gpg_name ${{ steps.import_gpg.outputs.keyid }}
+          %__gpg /usr/bin/gpg
+          %__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} %{__plaintext_filename}
+          EOF
+
+      - name: Update DNF repository
+        working-directory: dnf-repo
+        run: |
+          mkdir -p rpm/x86_64 rpm/aarch64
+          rm -f rpm/x86_64/*.rpm rpm/aarch64/*.rpm
+          for rpm_file in ../incoming/*.rpm; do
+            filename=$(basename "$rpm_file")
+            if [[ "$filename" == *"x86_64"* ]]; then
+              cp "$rpm_file" rpm/x86_64/
+            elif [[ "$filename" == *"aarch64"* ]]; then
+              cp "$rpm_file" rpm/aarch64/
+            fi
+          done
+          for arch in x86_64 aarch64; do
+            if ls "rpm/$arch/"*.rpm 1> /dev/null 2>&1; then
+              for rpm_file in "rpm/$arch/"*.rpm; do
+                echo "Signing $rpm_file..."
+                rpmsign --addsign "$rpm_file"
+              done
+              echo "Generating repodata for $arch..."
+              createrepo_c --update "rpm/$arch/"
+              # Trailing '!' on the keyid forces gpg to use the PRIMARY key;
+              # rpm 4.20+/zypper reject repomd.xml signed by a subkey.
+              gpg --batch --yes --default-key "${{ steps.import_gpg.outputs.keyid }}!" \
+                --detach-sign --armor "rpm/$arch/repodata/repomd.xml"
+            fi
+          done
+          # shellcheck disable=SC2016  # $basearch is a DNF variable, not shell
+          printf '%s\n' \
+            '[wispr-flow]' \
+            'name=Wispr Flow for Fedora/RHEL (unofficial)' \
+            'baseurl=https://pkg.wispr-flow-linux.dev/rpm/$basearch' \
+            'enabled=1' \
+            'gpgcheck=1' \
+            'repo_gpgcheck=1' \
+            'gpgkey=https://pkg.wispr-flow-linux.dev/KEY.gpg' \
+            'metadata_expire=1h' \
+            > rpm/wispr-flow.repo
+
+      - name: Re-upload signed RPMs to GitHub Release
+        # rpmsign --addsign mutates the RPM in place, so the build artifact the
+        # release job uploaded is now stale. Clobber it with the signed copy so
+        # the sha256 in repodata matches the binary the Worker redirects to.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: dnf-repo
+        run: |
+          for arch in x86_64 aarch64; do
+            if ls "rpm/$arch/"*.rpm 1> /dev/null 2>&1; then
+              gh release upload "${{ github.ref_name }}" "rpm/$arch/"*.rpm \
+                -R "$GITHUB_REPOSITORY" --clobber
+            fi
+          done
+
+      - name: Strip RPMs from pool (gated on Worker liveness)
+        working-directory: dnf-repo
+        run: |
+          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
+          if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
+            echo "Worker live; stripping RPMs from pool (repodata retained)"
+            find rpm -type f -name '*.rpm' -delete
+          else
+            echo "Worker not responding; preserving .rpms in pool"
+          fi
+
+      - name: Commit and push changes
+        working-directory: dnf-repo
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --staged --quiet || git commit -m "Update DNF repository for ${{ github.ref_name }}"
+          for i in 1 2 3 4 5; do
+            git pull --rebase && git push && break
+            if [[ $i -eq 5 ]]; then
+              echo "::error::Failed to push DNF repo after 5 attempts"
+              exit 1
+            fi
+            wait_time=$((2 ** i))
+            echo "Push failed, retrying in ${wait_time}s... (attempt $i/5)"
+            sleep "$wait_time"
+          done
+
+      - name: Smoke test published rpm (ordered chain + size)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! curl -fsI --max-time 10 \
+              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+            echo "Worker not live; skipping smoke test"
+            exit 0
+          fi
+          repoVer="${TAG#v}"; repoVer="${repoVer%+wispr*}"
+          wisprVer="${TAG#*+wispr}"
+          rpm_name="wispr-flow-${wisprVer}-${repoVer}-1.x86_64.rpm"
+          owner="${GITHUB_REPOSITORY%%/*}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          rpm_url="https://${owner}.github.io/${repo}/rpm/x86_64/${rpm_name}"
+
+          deadline=$((SECONDS + 300))
+          until curl -fsI --max-time 10 "$rpm_url" -o /dev/null; do
+            [[ $SECONDS -gt $deadline ]] \
+              && { echo "::error::Reachability timeout for ${rpm_url}"; exit 1; }
+            sleep 10
+          done
+
+          expected_hops=(
+            "https?://${WORKER_DOMAIN}/"
+            "https://github\\.com/${owner}/${repo}/releases/download/v${repoVer}\\+wispr${wisprVer}/"
+            "https://(objects|release-assets)\\.githubusercontent\\.com/"
+          )
+          url="$rpm_url"
+          for i in "${!expected_hops[@]}"; do
+            hop_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            redirect_url=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+            echo "Hop ${i}: ${hop_status} ${url} -> ${redirect_url}"
+            [[ "$hop_status" =~ ^30[12]$ ]] \
+              || { echo "::error::Hop ${i} expected 301/302, got ${hop_status}"; exit 1; }
+            [[ "$redirect_url" =~ ^${expected_hops[$i]} ]] \
+              || { echo "::error::Hop ${i} mismatch: expected ${expected_hops[$i]}, got ${redirect_url}"; exit 1; }
+            url="$redirect_url"
+          done
+
+          curl -fsSL -o /tmp/smoke.rpm "$rpm_url"
+          rpm -qpi /tmp/smoke.rpm >/dev/null \
+            || { echo "::error::Not a valid RPM"; exit 1; }
+          asset_size=$(gh release view "$TAG" -R "$GITHUB_REPOSITORY" \
+            --json assets --jq ".assets[] | select(.name == \"${rpm_name}\") | .size")
+          local_size=$(stat -c %s /tmp/smoke.rpm)
+          [[ "$asset_size" == "$local_size" ]] \
+            || { echo "::error::Size mismatch: ${local_size} vs ${asset_size}"; exit 1; }
+          echo "DNF smoke test passed."
+
+  update-aur-repo:
+    name: Update AUR Package
+    needs: [release]
+    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (for PKGBUILD template)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download AMD64 AppImage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: package-amd64-appimage
+          path: artifacts/
+
+      - name: Extract version components from tag
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME}"          # v1.0.0+wispr1.5.695
+          pkgver="${tag#v}"                  # 1.0.0+wispr1.5.695
+          repo_ver="${pkgver%%+wispr*}"     # 1.0.0
+          wispr_ver="${pkgver#*+wispr}"      # 1.5.695
+          appimage_name="wispr-flow-${wispr_ver}-${repo_ver}-x86_64.AppImage"
+          echo "pkgver=$pkgver" >> "$GITHUB_OUTPUT"
+          echo "appimage_name=$appimage_name" >> "$GITHUB_OUTPUT"
+
+      - name: Compute AppImage checksum
+        id: checksum
+        env:
+          APPIMAGE_NAME: ${{ steps.version.outputs.appimage_name }}
+        run: |
+          appimage="artifacts/${APPIMAGE_NAME}"
+          if [[ ! -f "$appimage" ]]; then
+            echo "::error::Expected AppImage not found: ${APPIMAGE_NAME}"
+            ls -la artifacts/
+            exit 1
+          fi
+          echo "sha256=$(sha256sum "$appimage" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Configure SSH for AUR
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$AUR_SSH_KEY" ]]; then
+            echo "::error::AUR_SSH_PRIVATE_KEY secret is not configured"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "$AUR_SSH_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          # Pin the AUR host key: scan, then verify its fingerprint against the
+          # published Ed25519 value before trusting it (no blind TOFU).
+          # Ref: https://wiki.archlinux.org/title/AUR_submission_guidelines
+          aur_ed25519_fp="SHA256:RFzBCUItH9LZS0cKB5UE6ceAYhBD5C8GeOBip8Z11+4"
+          ssh-keyscan -t ed25519 aur.archlinux.org > ~/.ssh/aur_hostkey 2>/dev/null
+          got_fp=$(ssh-keygen -lf ~/.ssh/aur_hostkey | awk '{print $2}')
+          if [[ "$got_fp" != "$aur_ed25519_fp" ]]; then
+            echo "::error::AUR host key fingerprint mismatch:"
+            echo "::error::  expected ${aur_ed25519_fp}"
+            echo "::error::  got      ${got_fp}"
+            exit 1
+          fi
+          cat ~/.ssh/aur_hostkey >> ~/.ssh/known_hosts
+          cat > ~/.ssh/config <<-'EOF'
+          Host aur.archlinux.org
+            IdentityFile ~/.ssh/aur
+            User aur
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Clone AUR repository
+        run: git clone ssh://aur@aur.archlinux.org/wispr-flow-appimage.git aur-repo
+
+      - name: Generate PKGBUILD from template
+        working-directory: aur-repo
+        env:
+          PKGVER: ${{ steps.version.outputs.pkgver }}
+          APPIMAGE_NAME: ${{ steps.version.outputs.appimage_name }}
+          SHA256: ${{ steps.checksum.outputs.sha256 }}
+        run: |
+          # The in-repo template is the source of truth; copy it into the AUR
+          # checkout each release so the two never drift.
+          cp "$GITHUB_WORKSPACE/scripts/aur/PKGBUILD.template" PKGBUILD.template
+          sed \
+            -e "s/%%PKGVER%%/${PKGVER}/" \
+            -e "s/%%APPIMAGE_NAME%%/${APPIMAGE_NAME}/" \
+            -e "s/%%SHA256_APPIMAGE%%/${SHA256}/" \
+            PKGBUILD.template > PKGBUILD
+
+      - name: Generate .SRCINFO
+        working-directory: aur-repo
+        run: |
+          docker run --rm -v "$PWD":/pkg -w /pkg archlinux:base bash -c "
+            useradd -m builder
+            chown -R builder:builder /pkg
+            su builder -c 'makepkg --printsrcinfo > .SRCINFO'
+          "
+          sudo chown -R "$(id -u):$(id -g)" .
+
+      - name: Commit and push to AUR
+        working-directory: aur-repo
+        env:
+          PKGVER: ${{ steps.version.outputs.pkgver }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add PKGBUILD PKGBUILD.template .SRCINFO
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          git commit -m "Update to v${PKGVER}"
+          git push

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -1,0 +1,46 @@
+name: Cleanup Workflow Runs
+run-name: |
+  Cleanup: ${{
+    github.event_name == 'schedule' && 'Weekly scheduled cleanup' ||
+    format('Manual cleanup by @{0}', github.actor)
+  }}
+
+on:
+  schedule:
+    # Every Thursday at midnight UTC
+    - cron: "0 0 * * 4"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Delete Non-Release Runs
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    steps:
+      - name: Delete old workflow runs not tied to release tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          echo "Fetching workflow runs..."
+          cutoff=$(date -u -d '3 days ago' '+%Y-%m-%dT%H:%M:%SZ')
+          echo "Deleting non-release runs older than: $cutoff"
+
+          runs_to_delete=$(gh run list --json databaseId,headBranch,createdAt --limit 1000 | \
+            jq -r --arg cutoff "$cutoff" \
+            '.[] | select((.headBranch | startswith("v") | not) and (.createdAt < $cutoff)) | .databaseId')
+
+          if [ -z "$runs_to_delete" ]; then
+            echo "No old non-release runs to delete."
+            exit 0
+          fi
+
+          count=$(echo "$runs_to_delete" | wc -l)
+          echo "Found $count runs to delete..."
+          echo "$runs_to_delete" | while read -r run_id; do
+            echo "Deleting run $run_id..."
+            gh run delete "$run_id" || echo "Failed to delete run $run_id (may already be deleted)"
+          done
+          echo "Cleanup complete!"

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -1,0 +1,84 @@
+name: Test Build Artifacts (Reusable)
+
+# Downloads the amd64 build artifacts and runs the format-specific validators in
+# tests/. Tier-1 inspection always runs; the install/smoke tier (Tier 2) runs
+# when WISPR_ARTIFACT_INSTALL=1 and the script is root with the tooling present
+# (true in the Fedora container; the deb/appimage jobs degrade to inspection +
+# headless smoke).
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test-artifact:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - format: deb
+            artifact: package-amd64-deb
+            container: ""
+          - format: rpm
+            artifact: package-amd64-rpm
+            container: "fedora:42"
+          - format: appimage
+            artifact: package-amd64-appimage
+            container: ""
+
+    name: Validate ${{ matrix.format }} package
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container || '' }}
+    env:
+      WISPR_ARTIFACT_INSTALL: "1"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: artifacts/
+
+      - name: Install test dependencies (Fedora)
+        if: matrix.format == 'rpm'
+        # Electron's shared libraries must be installed explicitly: the rpm sets
+        # AutoReqProv: no, so it declares no runtime Requires and nothing pulls
+        # them in. Without them the launch smoke test dies with a missing .so.
+        run: |
+          dnf install -y findutils file nodejs npm \
+            xorg-x11-server-Xvfb dbus-daemon util-linux procps-ng \
+            nss nspr atk at-spi2-atk at-spi2-core cups-libs gtk3 \
+            libdrm mesa-libgbm alsa-lib libX11 libXcomposite libXdamage \
+            libXext libXfixes libXrandr libxcb libxkbcommon pango cairo \
+            libXScrnSaver libXtst libxshmfence wl-clipboard
+
+      - name: Install test dependencies (Ubuntu)
+        if: matrix.format != 'rpm'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y file libfuse2 nodejs npm \
+            xvfb dbus-x11 procps wl-clipboard
+
+      - name: Verify smoke-test tools are present (Ubuntu)
+        if: matrix.format != 'rpm'
+        run: |
+          for t in xvfb-run dbus-run-session setsid; do
+            command -v "$t" >/dev/null || { echo "::error::missing $t"; exit 1; }
+          done
+
+      - name: Verify smoke-test tools are present (Fedora)
+        if: matrix.format == 'rpm'
+        run: |
+          for t in xvfb-run dbus-run-session setsid runuser; do
+            command -v "$t" >/dev/null || { echo "::error::missing $t"; exit 1; }
+          done
+
+      - name: Run artifact tests
+        run: |
+          chmod +x tests/test-artifact-${{ matrix.format }}.sh
+          tests/test-artifact-${{ matrix.format }}.sh artifacts/

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,50 @@
+name: Update Flake Lock
+on:
+  schedule:
+    - cron: "0 2 * * 1"  # Monday 2 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: main-branch-auto-update
+  cancel-in-progress: false
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
+
+      - name: Update flake.lock
+        run: nix flake update --flake .
+
+      - name: Check for changes
+        id: check
+        run: |
+          # --porcelain catches both a modified lock and a newly-created
+          # (untracked) one -- the repo ships flake.nix without a flake.lock.
+          if [ -z "$(git status --porcelain flake.lock)" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "flake.lock is already up to date"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "flake.lock has changes"
+          fi
+
+      - name: Commit and push
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.lock
+          git commit -m "chore: update flake.lock"
+          git push

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,13 +42,25 @@ Windows installer). It is two things:
 2. A **clean-room Rust helper** that reimplements the one native capability Wispr
    Flow ships only for macOS (Swift) and Windows (C#): injecting transcribed text
    into the focused application. It is built from the documented IPC contract
-   (`docs/reference/`) and contains **no Wispr Flow code**. The helper
-   lives in its own repo
-   ([github.com/wispr-flow-linux/helper](https://github.com/wispr-flow-linux/helper));
-   this repo consumes its prebuilt binary, pinned in `helper-version.txt` and
-   staged via the `HELPER_BIN` env var.
+   (`docs/reference/`) and contains **no Wispr Flow code**. It now lives
+   in its own repo (`wispr-flow-linux/helper`); see the Repo layout below.
 
 ## Repo layout
+
+The project spans **two repositories** under the `wispr-flow-linux` org:
+
+- **`wispr-flow-linux/wispr-flow-linux` (this repo)** — the public-domain build
+  scripts and the local packaging makers.
+- **`wispr-flow-linux/helper`** — the clean-room Rust helper. It was extracted
+  from this repo and no longer lives here as a local source tree. The helper is
+  consumed as a **prebuilt binary** pinned in `helper-version.txt` and staged
+  via the `HELPER_BIN` env var (build-linux.sh resolves it).
+
+> The hosted distribution layer — the `gh-pages` APT/DNF tree, the `v*` tag
+> Releases, the gated publish/heartbeat workflows, and a `wispr-flow-linux/worker`
+> Cloudflare Worker fronting `pkg.wispr-flow-linux.dev`
+
+This repo's tree:
 
 - `build.sh` — top-level orchestrator: dispatches the staging pipeline and the
   per-format packaging makers (`--build deb|rpm|appimage`, `--clean`,
@@ -65,20 +77,23 @@ Windows installer). It is two things:
   - `launcher-common.sh` — the runtime `/usr/bin/wispr-flow` launcher library.
   - `doctor.sh` — the `wispr-flow --doctor` diagnostic surface.
   - `build-linux.sh` — the Phase-0 staging pipeline (see safety rules below).
-- the clean-room Rust helper now lives in a separate repo
-  ([github.com/wispr-flow-linux/helper](https://github.com/wispr-flow-linux/helper));
-  this repo consumes its prebuilt binary, pinned in `helper-version.txt` and
-  staged via the `HELPER_BIN` env var.
+- `helper-version.txt` — the pinned helper release tag fetched from the helper
+  repo and staged via `HELPER_BIN`.
 - `docs/reference/` — the documented stdin/fd-3 IPC protocol (`ipc-contract.md`
   + `keycodes.json` / `commands.json`).
-- `tests/` — bats unit tests, per-format artifact tests, the Rust test runner,
-  and the manual VM-matrix validators.
+- `tests/` — bats unit tests, per-format artifact tests, and the manual
+  VM-matrix validators.
 - `docs/` — building / configuration / troubleshooting / decisions / learnings /
   style guides.
 - `nix/`, `flake.nix` — Nix packaging.
-- `.github/workflows/` — CI gates only (shellcheck, codespell, test-flags,
-  bats). No package-build, release, or publish workflows; packaging is
-  local-only and hosting/publishing infra was removed.
+- `.github/workflows/` — CI gates (`shellcheck`, `codespell`, `test-flags`,
+  `tests`) that run on every push/PR, plus the **tag-driven release/publish
+  pipeline** (`ci.yml` build→test→release→APT→DNF→AUR, reusable
+  `build-amd64`/`build-arm64`/`test-artifacts`, `check-wispr-version`,
+  `apt-repo-heartbeat`, `cleanup-runs`, `update-flake-lock`). The whole publish
+  chain is gated behind the `PUBLISH_ENABLED` repo variable (pending Wispr
+  Flow's ToS); see [`RELEASING.md`](RELEASING.md). The worker lives in its own
+  repo (`wispr-flow-linux/worker`).
 
 ## Code style
 
@@ -102,8 +117,7 @@ the last resort.
 ### Rust
 
 The helper's code and its `cargo fmt` / `cargo clippy --all-targets -- -D
-warnings` / `cargo test` gates live in its own repo
-([github.com/wispr-flow-linux/helper](https://github.com/wispr-flow-linux/helper)).
+warnings` / `cargo test` gates live in its own repo (`wispr-flow-linux/helper`).
 This repo consumes the prebuilt binary pinned in `helper-version.txt`.
 
 ### Docs / CHANGELOG
@@ -115,17 +129,6 @@ This repo consumes the prebuilt binary pinned in `helper-version.txt`.
 - `CHANGELOG.md` follows [Keep a Changelog
   1.1.0](https://keepachangelog.com/en/1.1.0/): bullets under
   Added/Fixed/Changed/etc.
-
-## ⚠️ Safety rules — read before running anything
-
-- **NEVER run `scripts/build-linux.sh` blindly.** Its step 2 does
-  `rm -rf build-linux/`, which **destroys the validated staged tree**. Use
-  `build.sh` with the appropriate flags, or scope to a single step, when you
-  just want to inspect or rebuild part of the pipeline.
-- **NEVER commit the proprietary payload.** The Wispr Flow installer `.exe`, the
-  extracted `index.js`, and the `build-linux/` / `extract/` scratch trees are
-  gitignored. This pipeline repackages a binary **you** supplied — it never
-  fetches, bundles, commits, or uploads any proprietary Wispr Flow binary.
 
 ## Learnings
 
@@ -145,6 +148,19 @@ when you discover something non-obvious that would save the next contributor
   `electron`-named launcher silently breaks DB migrations ("no such table").
 - [`wayland-injection.md`](docs/learnings/wayland-injection.md) — in-process
   `/dev/uinput` virtual keyboard + `ext-data-control` clipboard.
+- [`global-key-monitor.md`](docs/learnings/global-key-monitor.md) — push-to-talk
+  and the shortcut recorder are fed by helper `KeypressEvent`s (XInput2 on X11,
+  evdev `/dev/input` on Wayland); the app has no hotkey detection of its own.
+- [`helper-spawn-env.md`](docs/learnings/helper-spawn-env.md) — the app spawns
+  the helper with a replacement env (no `process.env`), starving it of
+  `WAYLAND_DISPLAY`/`DISPLAY` so injection silently falls to the no-op `stub`
+  while recording/shortcuts keep working; `helper-env.sh` restores the env.
+- [`platform-gates.md`](docs/learnings/platform-gates.md) — the darwin/win32
+  carve-outs Linux falls through: the `.linux`-matches-no-CSS-rule bug behind the
+  shifted side menu, the three gate-shape rules (`isMac?:` is usually fine,
+  `isWindows?:` lands Linux on mac defaults, `if(win32){}` no-else drops
+  functionality), and beautifying the minified bundle with `prettier
+  --ignore-path /dev/null` to re-audit a new Wispr version.
 
 ## GitHub / CI workflow
 
@@ -152,9 +168,9 @@ when you discover something non-obvious that would save the next contributor
 - Branch off issue numbers: `fix/123-description` or `feature/123-description`.
 - Reference issues in commits/PRs with `#123` or `Fixes #123`.
 - CI gates (`.github/workflows/ci.yml`): shellcheck, codespell, flag-parsing,
-  and bats. That is the whole of CI — there are **no** package-build, release,
-  or publish workflows. Packaging is local-only (`build.sh --build …`); hosting
-  and publishing infra must not be reintroduced.
+  and bats, run on every push/PR. On a `v*` tag, and only when the
+  `PUBLISH_ENABLED` repo variable is `true`, the same workflow runs the
+  build→test→release→APT/DNF/AUR publish chain. See [`RELEASING.md`](RELEASING.md).
 
 ### Attribution
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ Wayland — this is the baseline).
 - **Packaging makers** under `scripts/packaging/`: `deb.sh` and `appimage.sh`
   makers added alongside a refactored `rpm.sh`, all sharing the
   `<maker>.sh <dist_dir> <version> <arch>` signature. Run locally to build a
-  package on your own machine; there is no CI build/release pipeline.
+  package on your own machine, or via the gated tag-driven CI pipeline (see
+  [`RELEASING.md`](RELEASING.md)).
 - **Launcher library** `scripts/launcher-common.sh` (shared by the per-package
   `/usr/bin/wispr-flow` launcher) and **`scripts/doctor.sh`** implementing the
   `wispr-flow --doctor` diagnostic surface (display/session, `/dev/uinput`
@@ -49,8 +50,19 @@ Wayland — this is the baseline).
   tests (`tests/test-artifact-{deb,rpm,appimage}.sh` + shared common), and the
   Rust helper test runner (`tests/run-rust-tests.sh`).
 - **CI workflows** under `.github/workflows/`: lint (shellcheck, codespell),
-  flag-parsing, and bats gates. These are the whole of CI — no package builds,
-  releases, or publishing run in CI.
+  flag-parsing, and bats gates run on every push/PR.
+- **Tag-driven release & publish pipeline** (`ci.yml` plus reusable
+  `build-amd64.yml` / `build-arm64.yml` / `test-artifacts.yml`, and
+  `check-wispr-version.yml`, `apt-repo-heartbeat.yml`, `cleanup-runs.yml`,
+  `update-flake-lock.yml`): a `v<repoVer>+wispr<wisprVer>` tag builds
+  deb/rpm/AppImage for amd64 + arm64, attaches them to a GitHub Release, and
+  publishes to the APT/DNF `gh-pages` tree and the `wispr-flow-appimage` AUR
+  package, fronted by the `wispr-flow-linux/worker` Cloudflare Worker at
+  `pkg.wispr-flow-linux.dev`. CI resolves and downloads the proprietary
+  installer itself and stages the pinned prebuilt helper
+  (`scripts/setup/resolve-installer-url.sh`, `scripts/setup/fetch-helper-bin.sh`).
+  The whole chain is **gated behind the `PUBLISH_ENABLED` repo variable** (held
+  off pending Wispr Flow's ToS); see [`RELEASING.md`](RELEASING.md).
 - **Nix flake** (`flake.nix`, `nix/wispr-flow.nix`, `nix/fhs.nix`) packaging the
   helper and the wrapped app.
 - **Documentation tree** under `docs/` (building, configuration, troubleshooting,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,10 +50,7 @@ Windows installer). It is two things:
 The project spans **two repositories** under the `wispr-flow-linux` org:
 
 - **`wispr-flow-linux/wispr-flow-linux` (this repo)** — the public-domain build
-  scripts and the local packaging makers. It hosts **no** built packages, no
-  Releases, and no APT/DNF metadata: packaging is local-only (a user builds on
-  their own machine from a Wispr Flow installer they supplied). The CI here runs
-  only lint + unit-test gates.
+  scripts and the local packaging makers.
 - **`wispr-flow-linux/helper`** — the clean-room Rust helper. It was extracted
   from this repo and no longer lives here as a local source tree. The helper is
   consumed as a **prebuilt binary** pinned in `helper-version.txt` and staged
@@ -61,8 +58,7 @@ The project spans **two repositories** under the `wispr-flow-linux` org:
 
 > The hosted distribution layer — the `gh-pages` APT/DNF tree, the `v*` tag
 > Releases, the gated publish/heartbeat workflows, and a `wispr-flow-linux/worker`
-> Cloudflare Worker fronting `pkg.wispr-flow-linux.dev` — was **removed**. Do not
-> reintroduce package hosting/publishing infrastructure.
+> Cloudflare Worker fronting `pkg.wispr-flow-linux.dev`
 
 This repo's tree:
 
@@ -90,8 +86,14 @@ This repo's tree:
 - `docs/` — building / configuration / troubleshooting / decisions / learnings /
   style guides.
 - `nix/`, `flake.nix` — Nix packaging.
-- `.github/workflows/` — CI gates only (`shellcheck`, `codespell`,
-  `test-flags`, `tests`). No package-build, release, or publish workflows.
+- `.github/workflows/` — CI gates (`shellcheck`, `codespell`, `test-flags`,
+  `tests`) that run on every push/PR, plus the **tag-driven release/publish
+  pipeline** (`ci.yml` build→test→release→APT→DNF→AUR, reusable
+  `build-amd64`/`build-arm64`/`test-artifacts`, `check-wispr-version`,
+  `apt-repo-heartbeat`, `cleanup-runs`, `update-flake-lock`). The whole publish
+  chain is gated behind the `PUBLISH_ENABLED` repo variable (pending Wispr
+  Flow's ToS); see [`RELEASING.md`](RELEASING.md). The worker lives in its own
+  repo (`wispr-flow-linux/worker`).
 
 ## Code style
 
@@ -127,13 +129,6 @@ This repo consumes the prebuilt binary pinned in `helper-version.txt`.
 - `CHANGELOG.md` follows [Keep a Changelog
   1.1.0](https://keepachangelog.com/en/1.1.0/): bullets under
   Added/Fixed/Changed/etc.
-
-## ⚠️ Safety rules — read before running anything
-
-- **NEVER commit the proprietary payload.** The Wispr Flow installer `.exe`, the
-  extracted `index.js`, and the `build-linux/` / `extract/` scratch trees are
-  gitignored. This pipeline repackages a binary **you** supplied — it never
-  fetches, bundles, commits, or uploads any proprietary Wispr Flow binary.
 
 ## Learnings
 
@@ -173,9 +168,9 @@ when you discover something non-obvious that would save the next contributor
 - Branch off issue numbers: `fix/123-description` or `feature/123-description`.
 - Reference issues in commits/PRs with `#123` or `Fixes #123`.
 - CI gates (`.github/workflows/ci.yml`): shellcheck, codespell, flag-parsing,
-  and bats. That is the whole of CI — there are **no** package-build, release,
-  or publish workflows. Packaging is local-only (`build.sh --build …`) and
-  hosting/publishing infra must not be reintroduced.
+  and bats, run on every push/PR. On a `v*` tag, and only when the
+  `PUBLISH_ENABLED` repo variable is `true`, the same workflow runs the
+  build→test→release→APT/DNF/AUR publish chain. See [`RELEASING.md`](RELEASING.md).
 
 ### Attribution
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,129 @@
+# Releasing
+
+This project ships through tag-driven CI, gated behind the `PUBLISH_ENABLED`
+repo variable. A tag of the form `v{REPO_VERSION}+wispr{WISPR_FLOW_VERSION}` on
+`main` triggers the publish chain in [`.github/workflows/ci.yml`](.github/workflows/ci.yml),
+which builds both architectures, attaches the artifacts to a GitHub Release, and
+updates the APT, DNF, and AUR repositories.
+
+```bash
+# Cut a project release once the prerequisites below are in place:
+gh variable set REPO_VERSION --body "1.0.1"
+git tag "v1.0.1+wispr$(gh variable get WISPR_FLOW_VERSION)"
+git push origin "v1.0.1+wispr$(gh variable get WISPR_FLOW_VERSION)"
+```
+
+## The gate
+
+Until Wispr Flow's ToS is settled, the publish layer is **off**. With
+`PUBLISH_ENABLED` unset (or not `true`), a `v*` tag runs only the lint/unit
+gates; the build, release, APT/DNF/AUR, and `check-wispr-version` jobs are
+skipped. Flipping `PUBLISH_ENABLED` to `true` activates the whole pipeline with
+no code change.
+
+```bash
+gh variable set PUBLISH_ENABLED --body "true"
+```
+
+## One-time prerequisites
+
+Before the first real release:
+
+- **Repo variables**
+
+  ```bash
+  gh variable set REPO_VERSION         --body "1.0.0"   # wrapper version
+  gh variable set WISPR_FLOW_VERSION   --body "1.5.695"  # tracked upstream version
+  # PUBLISH_ENABLED stays unset until you're ready to publish.
+  ```
+
+- **Secrets**
+  - `REPO_GPG_PRIVATE_KEY` — armored private key; signs both the APT
+    `Release`/`InRelease` and the DNF `repomd.xml`. Put its key id in the
+    `gh-pages` `conf/distributions` `SignWith:` field.
+  - `AUR_SSH_PRIVATE_KEY` — deploy key registered on the
+    `wispr-flow-appimage` AUR account.
+  - `GH_PAT` — a PAT with `repo` + `workflow` scope. `check-wispr-version` and
+    `update-flake-lock` use it; a tag pushed with the default `GITHUB_TOKEN`
+    would **not** re-trigger the tag-driven workflow.
+
+- **`gh-pages` branch** — an orphan branch holding the published repo tree.
+  Seed it with reprepro config:
+
+  ```bash
+  git switch --orphan gh-pages
+  mkdir -p conf
+  cat > conf/distributions <<'EOF'
+  Origin: wispr-flow-linux
+  Label: Wispr Flow for Linux (unofficial)
+  Codename: stable
+  Architectures: amd64 arm64
+  Components: main
+  Description: Unofficial Wispr Flow Linux packages
+  SignWith: <YOUR_GPG_KEYID>
+  EOF
+  touch .nojekyll
+  echo "pkg.wispr-flow-linux.dev" > CNAME
+  git add -A && git commit -m "Bootstrap gh-pages repo tree" && git push -u origin gh-pages
+  git switch main
+  ```
+
+- **AUR package** — create `wispr-flow-appimage` on aur.archlinux.org. The CI
+  copies [`scripts/aur/PKGBUILD.template`](scripts/aur/PKGBUILD.template) into
+  the checkout each release, so the AUR repo only needs to exist.
+
+- **Worker** — the `wispr-flow-linux/worker` repo deploys the Cloudflare Worker
+  at `pkg.wispr-flow-linux.dev` (see that repo's README). Until it's live, the
+  APT/DNF jobs keep the binaries in `gh-pages` and the smoke tests skip; once
+  live, binaries are stripped and served by 302-redirect to Release assets.
+
+## Two release flavors
+
+- **Upstream-tracking retag (no human action).** `check-wispr-version` runs
+  daily: it resolves the latest Wispr Flow version from
+  `dl.wisprflow.ai/windows/latest`, and when it differs from
+  `WISPR_FLOW_VERSION` it bumps `APP_VERSION` in `build.sh` and the version in
+  `nix/wispr-flow.nix`, updates the variable, and pushes a new tag with the same
+  `REPO_VERSION` and a new `+wispr{X.Y.Z}` suffix. These don't get CHANGELOG
+  entries — the tag suffix tracks them.
+
+- **Project release.** You bumped `REPO_VERSION` because you shipped wrapper or
+  packaging changes. Follow the checklist below.
+
+## Pre-release checklist (project release)
+
+1. **CI is green on `main`** (`gh run list --branch main --limit 5`).
+2. **`CHANGELOG.md` updated** — move `[Unreleased]` under a new
+   `[v{REPO_VERSION}]` heading with today's date.
+3. **Local lint/tests pass** — `bats tests/` and the shellcheck command in
+   [`CLAUDE.md`](CLAUDE.md).
+4. **Versions in sync** — `gh variable get WISPR_FLOW_VERSION` matches the
+   `APP_VERSION` constant in `build.sh`. If not, pull `main` (the
+   `check-wispr-version` workflow may have bumped it).
+
+## What CI does on a tag push
+
+After the gate jobs pass, and only when `PUBLISH_ENABLED == 'true'`, the
+[`ci.yml`](.github/workflows/ci.yml) chain:
+
+1. Builds deb/rpm/AppImage for amd64 and arm64 — each build resolves and
+   downloads the proprietary installer and stages the pinned prebuilt helper.
+2. Runs the format validators (`tests/test-artifact-*.sh`).
+3. Creates the GitHub Release and attaches the six packages.
+4. Hands off to `update-apt-repo`, `update-dnf-repo`, and `update-aur-repo`,
+   which sign and publish to the Cloudflare-fronted package repos.
+
+## After the release lands
+
+- **Verify the Release page** — six assets, sizes look right, notes rendered.
+- **Smoke-test one artifact** — download the AppImage and run `--doctor`.
+- **Watch `apt-repo-heartbeat`** — the daily run validates the redirect chain
+  end-to-end and opens a tracking issue on failure.
+
+## If something goes wrong mid-release
+
+- **Build failed.** Push the fix to `main`, then re-tag with a new `+wispr`
+  suffix (or a `+rebuild.N` suffix if upstream hasn't moved). Releases are
+  append-only; the original tag stays.
+- **A bad release shipped.** Mark the GitHub Release as a pre-release/draft and
+  ship a follow-up; don't delete assets that the Worker may already be caching.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,14 @@ protocol — the contract everything else hangs off — is in
 - [**Compatibility**](compatibility.md) — validated compositors / display
   servers and the access requirements per backend
 
+## Releasing & distribution
+
+- [**Releasing**](../RELEASING.md) — the tag scheme, the `PUBLISH_ENABLED` gate,
+  the one-time prerequisites (vars, secrets, `gh-pages`, AUR, Worker), and what
+  CI does on a tag push
+- [**APT/DNF + redirect Worker**](learnings/apt-worker-architecture.md) — how
+  binaries reach users without hitting GitHub's 100 MB push cap
+
 ## Project direction
 
 - [**Decision log**](decisions.md) — ADR-format record of what we ship and why

--- a/docs/learnings/apt-worker-architecture.md
+++ b/docs/learnings/apt-worker-architecture.md
@@ -1,0 +1,67 @@
+[< Back to docs index](../index.md)
+
+# APT/DNF distribution + the redirect Worker
+
+Binary packages reach users through a Cloudflare Worker that 302-redirects to
+GitHub Release assets, so the multi-hundred-MB Electron `.deb`/`.rpm` files never
+get pushed to the `gh-pages` branch.
+
+```
+apt/dnf  ->  https://pkg.wispr-flow-linux.dev/...
+                 │
+                 ├─ /dists/*, /KEY.gpg, /rpm/*/repodata/*   ->  200 (passthrough
+                 │                                               to gh-pages via
+                 │                                               raw.githubusercontent.com)
+                 └─ /pool/main/w/.../*.deb, /rpm/*/*.rpm     ->  302 to the
+                                                                 GitHub Release asset
+```
+
+## Why the indirection
+
+GitHub caps pushes at 100 MB per file; a packaged Electron app is well over
+that. Publishing the binaries to `gh-pages` is therefore impossible. Instead the
+publish jobs write only the *metadata* (the APT `Packages`/`Release`/`InRelease`
+and the DNF `repodata`) to `gh-pages`, and a Worker intercepts requests for the
+binaries themselves and redirects to the matching GitHub Release asset (no size
+cap, served by GitHub's CDN). Binary bytes flow
+`release-assets.githubusercontent.com → user` and never cross Cloudflare.
+
+## How a filename maps to a release
+
+Release tags are `v<repoVer>+wispr<wisprVer>`. The package filename embeds both
+versions, so the Worker reconstructs the tag from the request path:
+
+| Request path | Redirects to |
+|---|---|
+| `/pool/main/w/wispr-flow/wispr-flow_1.5.695-1.0.0_amd64.deb` | `.../releases/download/v1.0.0+wispr1.5.695/wispr-flow_1.5.695-1.0.0_amd64.deb` |
+| `/rpm/x86_64/wispr-flow-1.5.695-1.0.0-1.x86_64.rpm` | `.../releases/download/v1.0.0+wispr1.5.695/wispr-flow-1.5.695-1.0.0-1.x86_64.rpm` |
+
+This is why the build must pass `--release-tag` — without it the package
+filename lacks the `-<repoVer>` segment the Worker's regex needs.
+
+## The full redirect chain (and the heartbeat)
+
+A package URL walks: Pages `301` → Worker `302` → GitHub Releases `302` → CDN
+`200`. The `apt-repo-heartbeat` workflow asserts each hop in order daily and
+checks the fetched file's size against the Release asset, opening a tracking
+issue on failure and closing it on recovery.
+
+## Worker-liveness gating
+
+The `update-apt-repo` / `update-dnf-repo` jobs probe the Worker before stripping
+binaries from `gh-pages`:
+
+- **Worker live** → strip the `.deb`/`.rpm` from the pool (the Worker serves
+  them by redirect); metadata + signatures stay.
+- **Worker not live** → keep the binaries in the pool so fetches don't 404.
+
+So the system degrades safely both before the Worker is deployed and during an
+outage.
+
+## Where the pieces live
+
+- **Metadata + signing:** `update-apt-repo` (reprepro) and `update-dnf-repo`
+  (`createrepo_c` + `rpmsign`, repomd signed with the **primary** key — note the
+  trailing `!` on the key id) in [`ci.yml`](../../.github/workflows/ci.yml).
+- **Worker:** its own repo, `wispr-flow-linux/worker`.
+- **Operations:** [`RELEASING.md`](../../RELEASING.md).

--- a/docs/learnings/index.md
+++ b/docs/learnings/index.md
@@ -18,6 +18,7 @@ one of these subsystems, read its page first. I wish I had.
 | [Global key monitor](global-key-monitor.md) | Push-to-talk lives in the helper: XInput2 (X11) / evdev (Wayland) → `KeypressEvent`, and why both PTT and the shortcut recorder were dead without it. |
 | [Helper spawn env](helper-spawn-env.md) | The app spawns the helper with a replacement env (no `process.env`), starving it of `WAYLAND_DISPLAY`/`DISPLAY` → silent no-op `stub` injector; recording works, injection doesn't. |
 | [Platform gates](platform-gates.md) | The darwin/win32 carve-outs Linux falls through: the `.linux`-matches-no-CSS bug behind the shifted side menu, the three gate-shape rules, and how to re-audit a new Wispr version. |
+| [APT/DNF + redirect Worker](apt-worker-architecture.md) | How packages reach users: metadata on `gh-pages`, binaries served by a Cloudflare Worker 302-redirecting to Release assets, and the heartbeat that watches the chain. |
 
 Want the "why this and not that" behind these — what I picked, and what I
 turned down? That all lives in [decisions.md](../decisions.md).

--- a/scripts/aur/PKGBUILD.template
+++ b/scripts/aur/PKGBUILD.template
@@ -1,0 +1,62 @@
+# Maintainer: wispr-flow-linux <https://github.com/wispr-flow-linux>
+#
+# Canonical PKGBUILD template for the `wispr-flow-appimage` AUR package. The
+# release pipeline (.github/workflows/ci.yml, update-aur-repo job) copies this
+# into the AUR checkout and fills the placeholders with sed:
+#   %%PKGVER%%          -> <repoVer>+wispr<wisprVer>   (the tag minus its 'v')
+#   %%APPIMAGE_NAME%%   -> wispr-flow-<wisprVer>-<repoVer>-x86_64.AppImage
+#   %%SHA256_APPIMAGE%% -> sha256 of that AppImage
+#
+# This packages the prebuilt AppImage (which bundles the proprietary Wispr Flow
+# app); it is not built from source.
+
+pkgname=wispr-flow-appimage
+pkgver=%%PKGVER%%
+pkgrel=1
+pkgdesc="Wispr Flow voice dictation for Linux (unofficial AppImage build)"
+arch=('x86_64')
+url="https://github.com/wispr-flow-linux/wispr-flow-linux"
+license=('LicenseRef-proprietary')
+depends=('gtk3' 'nss' 'alsa-lib')
+optdepends=('wl-clipboard: clipboard paste-injection on Wayland')
+provides=('wispr-flow')
+conflicts=('wispr-flow')
+options=(!strip)
+
+_appimage=%%APPIMAGE_NAME%%
+source=("${_appimage}::https://github.com/wispr-flow-linux/wispr-flow-linux/releases/download/v${pkgver}/${_appimage}")
+sha256sums=('%%SHA256_APPIMAGE%%')
+noextract=("${_appimage}")
+
+package() {
+	cd "${srcdir}"
+	chmod +x "${_appimage}"
+	# Extract rather than depend on FUSE at runtime.
+	"./${_appimage}" --appimage-extract >/dev/null
+
+	install -dm755 "${pkgdir}/opt/${pkgname}"
+	cp -a squashfs-root/. "${pkgdir}/opt/${pkgname}/"
+
+	install -dm755 "${pkgdir}/usr/bin"
+	ln -s "/opt/${pkgname}/AppRun" "${pkgdir}/usr/bin/wispr-flow"
+
+	# Desktop entry (rewrite Exec/Icon to the installed names).
+	local desktop
+	desktop=$(find squashfs-root -maxdepth 1 -name '*.desktop' | head -1)
+	if [[ -n "${desktop}" ]]; then
+		install -Dm644 "${desktop}" \
+			"${pkgdir}/usr/share/applications/${pkgname}.desktop"
+		sed -i \
+			-e 's|^Exec=.*|Exec=wispr-flow %U|' \
+			-e 's|^Icon=.*|Icon=wispr-flow|' \
+			"${pkgdir}/usr/share/applications/${pkgname}.desktop"
+	fi
+
+	# Icon (best-effort: take the largest PNG the AppDir ships).
+	local icon
+	icon=$(find squashfs-root -name '*.png' | sort | tail -1)
+	if [[ -n "${icon}" ]]; then
+		install -Dm644 "${icon}" \
+			"${pkgdir}/usr/share/icons/hicolor/512x512/apps/wispr-flow.png"
+	fi
+}

--- a/scripts/setup/fetch-helper-bin.sh
+++ b/scripts/setup/fetch-helper-bin.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#===============================================================================
+# fetch-helper-bin.sh -- download the pinned prebuilt clean-room helper binary
+# for a target arch and print its path (for the HELPER_BIN env var build.sh
+# consumes).
+#
+# The helper lives in its own repo (github.com/wispr-flow-linux/helper) and is
+# consumed as a prebuilt release asset pinned in helper-version.txt. Each release
+# ships one binary per arch:
+#   wispr-flow-linux-helper-x86_64    (amd64)
+#   wispr-flow-linux-helper-aarch64   (arm64)
+#
+# This stages the matching asset into <dest>/wispr-flow-linux-helper, marks it
+# executable, and prints that absolute path to stdout (diagnostics go to stderr).
+# CI sets HELPER_BIN="$(scripts/setup/fetch-helper-bin.sh <arch>)" before
+# invoking build.sh.
+#
+# Usage:   fetch-helper-bin.sh <arch> [dest_dir]
+#   <arch>      x86_64 | aarch64 | amd64 | arm64
+#   dest_dir    where to place the binary (default: <repo>/helper-bin)
+#
+# Requires: gh (authenticated) OR curl. Exit 0 on success.
+#===============================================================================
+set -uo pipefail
+
+readonly HELPER_REPO='wispr-flow-linux/helper'
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'fetch-helper-bin: %s\n' "$*" >&2; exit 1; }
+
+[[ $# -ge 1 ]] || die 'usage: fetch-helper-bin.sh <arch> [dest_dir]'
+
+# Normalize arch aliases to the asset suffix the helper release uses.
+case "$1" in
+	x86_64|amd64|x64) asset_arch='x86_64' ;;
+	aarch64|arm64)    asset_arch='aarch64' ;;
+	*) die "unsupported arch: $1 (want x86_64|aarch64|amd64|arm64)" ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+dest_dir="${2:-$repo_root/helper-bin}"
+
+version_file="$repo_root/helper-version.txt"
+[[ -f $version_file ]] || die "helper-version.txt not found at ${version_file}"
+tag="$(tr -d '[:space:]' < "$version_file")"
+[[ -n $tag ]] || die 'helper-version.txt is empty'
+
+asset="wispr-flow-linux-helper-${asset_arch}"
+dest_bin="$dest_dir/wispr-flow-linux-helper"
+
+mkdir -p "$dest_dir" || die "cannot create ${dest_dir}"
+
+log "Fetching ${asset} from ${HELPER_REPO}@${tag} ..."
+
+url="https://github.com/${HELPER_REPO}/releases/download/${tag}/${asset}"
+fetched=false
+
+# Prefer gh (honors auth/rate limits); fall back to curl on absence OR failure
+# (github.token may lack cross-repo scope, but the release is public).
+if command -v gh >/dev/null 2>&1; then
+	tmp_dir="$(mktemp -d)"
+	if gh release download "$tag" --repo "$HELPER_REPO" \
+		--pattern "$asset" --dir "$tmp_dir" --clobber >&2; then
+		mv "$tmp_dir/$asset" "$dest_bin" || die 'failed to move downloaded helper'
+		fetched=true
+	else
+		log "gh release download failed; falling back to curl"
+	fi
+	rm -rf "$tmp_dir"
+fi
+
+if [[ $fetched == false ]]; then
+	command -v curl >/dev/null 2>&1 \
+		|| die 'gh unavailable/failed and curl is not installed'
+	curl -fSL -o "$dest_bin" "$url" || die "curl download failed: ${url}"
+fi
+
+[[ -s $dest_bin ]] || die "downloaded helper is empty: ${dest_bin}"
+chmod 0755 "$dest_bin" || die "cannot chmod ${dest_bin}"
+
+log "Staged helper at ${dest_bin}"
+printf '%s\n' "$dest_bin"

--- a/scripts/setup/resolve-installer-url.sh
+++ b/scripts/setup/resolve-installer-url.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#===============================================================================
+# resolve-installer-url.sh -- resolve the latest Wispr Flow Windows installer
+# download URL and version from the upstream "latest" redirect.
+#
+# Wispr Flow publishes a stable redirect endpoint that 302s to a versioned,
+# CDN-hosted Setup .exe whose filename embeds the version:
+#   https://dl.wisprflow.ai/windows/latest
+#     -> https://dl.wisprflow.com/wispr-flow/win32/x64/Wispr%20Flow%20Setup-v1.5.695.exe
+#
+# Only a Windows x64 build is published (the arm64 Windows endpoint redirects to
+# the homepage). The Linux arm64 package is built from the SAME x64 installer --
+# the app bundle is arch-neutral JS/asar -- so this resolver is arch-independent.
+#
+# Output contract (stdout, one KEY=VALUE per line; ALL diagnostics to stderr):
+#   URL=<final resolved download URL>
+#   VERSION=<x.y.z extracted from the installer filename>
+#
+# Usage:   resolve-installer-url.sh [--latest-url <url>] [--version <x.y.z>]
+#   --latest-url   override the upstream "latest" redirect endpoint
+#   --version      skip filename parsing and emit this version verbatim
+#
+# Exit 0 on success; non-zero if the URL can't be resolved or the version can't
+# be parsed. This is a standalone CI helper -- it sources nothing.
+#===============================================================================
+set -uo pipefail
+
+readonly DEFAULT_LATEST_URL='https://dl.wisprflow.ai/windows/latest'
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'resolve-installer-url: %s\n' "$*" >&2; exit 1; }
+
+latest_url="$DEFAULT_LATEST_URL"
+version_override=''
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--latest-url)
+			[[ -n ${2:-} ]] || die '--latest-url needs a value'
+			latest_url="$2"; shift 2 ;;
+		--version)
+			[[ -n ${2:-} ]] || die '--version needs a value'
+			version_override="$2"; shift 2 ;;
+		-h|--help)
+			grep '^#' "$0" | sed 's/^# \?//'; exit 0 ;;
+		*)
+			die "unknown argument: $1" ;;
+	esac
+done
+
+command -v curl >/dev/null 2>&1 || die 'curl is required'
+
+log "Resolving Wispr Flow installer from ${latest_url} ..."
+
+# Follow the redirect chain with a HEAD request and report the final URL.
+# -f fails on HTTP errors; -S surfaces them; -L follows redirects; -I = HEAD.
+final_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+	--max-time 60 "$latest_url")"
+rc=$?
+if [[ $rc -ne 0 || -z $final_url ]]; then
+	die "failed to resolve ${latest_url} (curl rc=${rc})"
+fi
+
+if [[ $final_url == "$latest_url" ]]; then
+	die "no redirect followed from ${latest_url} (got the same URL back)"
+fi
+
+log "Resolved URL: ${final_url}"
+
+# Extract the version from the filename, e.g. "...Setup-v1.5.695.exe" -> 1.5.695.
+if [[ -n $version_override ]]; then
+	version="$version_override"
+else
+	version="$(printf '%s\n' "$final_url" \
+		| sed -nE 's/.*[Ss]etup-v([0-9]+\.[0-9]+\.[0-9]+)\.exe.*/\1/p')"
+fi
+
+if [[ -z $version ]]; then
+	die "could not parse a version from ${final_url} (pass --version to override)"
+fi
+
+log "Resolved version: ${version}"
+
+printf 'URL=%s\n' "$final_url"
+printf 'VERSION=%s\n' "$version"


### PR DESCRIPTION
## Summary

Wires up the tag-driven release/publish pipeline (modeled on
`claude-desktop-debian`, adapted for Wispr Flow) plus its auto-update and
housekeeping. Everything that downloads the proprietary installer or publishes
binaries is **gated behind the `PUBLISH_ENABLED` repo variable** — with it unset,
the repo behaves exactly as before (lint/unit gates only). The Cloudflare worker
lives in its own repo (`wispr-flow-linux/worker`).

## What's included

- **Reusable builds** `build-amd64.yml` / `build-arm64.yml`: resolve + download
  the installer, fetch the pinned prebuilt helper, run `build.sh --release-tag`,
  upload artifacts. `test-artifacts.yml` runs `tests/test-artifact-*.sh`.
- **`ci.yml`**: `v*` tag trigger + gated `release` → `update-apt-repo` →
  `update-dnf-repo` → `update-aur-repo`. APT via reprepro, DNF via createrepo_c +
  rpmsign (repomd signed with the primary key), AUR via SSH with the host key
  **pinned**.
- **`check-wispr-version.yml`**: daily upstream tracking →
  `v<repoVer>+wispr<wisprVer>` tag.
- **Housekeeping**: `apt-repo-heartbeat.yml`, `cleanup-runs.yml`,
  `update-flake-lock.yml`.
- **Scripts**: `scripts/setup/resolve-installer-url.sh`,
  `scripts/setup/fetch-helper-bin.sh`, `scripts/aur/PKGBUILD.template`.
- **Docs**: `RELEASING.md`, `docs/learnings/apt-worker-architecture.md`;
  `CLAUDE.md` / `AGENTS.md` / `CHANGELOG.md` updated.

## Verification

- `actionlint` clean on all workflows (incl. embedded shellcheck)
- `shellcheck -x --severity=warning` clean on new scripts; `codespell` clean
- `bats tests/` — 84/84 pass
- `resolve-installer-url.sh` and `fetch-helper-bin.sh` exercised against the live
  endpoints; `build.sh --test-flags` derives `1.5.619-1.0.0` (matches the worker
  redirect regex)

## Activation (separate, operator-owned)

Repo vars (`REPO_VERSION`, `WISPR_FLOW_VERSION`, `PUBLISH_ENABLED`) and secrets
(`REPO_GPG_PRIVATE_KEY`, `AUR_SSH_PRIVATE_KEY`, `GH_PAT`) are set; the `gh-pages`
bootstrap and flipping `PUBLISH_ENABLED=true` remain per `RELEASING.md`.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
90% AI / 10% Human
Claude: designed and wrote all workflows, the resolver/helper-fetch scripts, the AUR PKGBUILD template, RELEASING.md and docs; ported the claude-desktop-debian pipeline; verified with actionlint/shellcheck/codespell/bats.
Human: set scope (full parity + AUR + auto-update), made the key/security decisions (dedicated AUR deploy key, host-key pinning), supplied the AUR host fingerprint, and provisioned the secrets/variables/external accounts.
