### PR TITLE
Point publish smoke tests + heartbeat at the Worker domain (no GitHub Pages dependency)

### DIFF
--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -45,18 +45,16 @@ jobs:
         if: steps.gate.outputs.live == 'true'
         id: latest
         run: |
-          owner="${GITHUB_REPOSITORY%%/*}"
-          repo="${GITHUB_REPOSITORY#*/}"
           tag=$(gh release list --limit 1 --json tagName \
                   --jq '.[0].tagName' -R "$GITHUB_REPOSITORY")
           repoVer="${tag#v}"; repoVer="${repoVer%+wispr*}"
           wisprVer="${tag#*+wispr}"
           if [[ "${{ matrix.format }}" == "deb" ]]; then
             asset="wispr-flow_${wisprVer}-${repoVer}_amd64.deb"
-            url="https://${owner}.github.io/${repo}/pool/main/w/wispr-flow/${asset}"
+            url="https://${WORKER_DOMAIN}/pool/main/w/wispr-flow/${asset}"
           else
             asset="wispr-flow-${wisprVer}-${repoVer}-1.x86_64.rpm"
-            url="https://${owner}.github.io/${repo}/rpm/x86_64/${asset}"
+            url="https://${WORKER_DOMAIN}/rpm/x86_64/${asset}"
           fi
           {
             echo "tag=${tag}"
@@ -86,7 +84,6 @@ jobs:
           done
 
           expected_hops=(
-            "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/${owner}/${repo}/releases/download/"
             "https://(objects|release-assets)\\.githubusercontent\\.com/"
           )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,10 @@ jobs:
           deb_name="wispr-flow_${wisprVer}-${repoVer}_amd64.deb"
           owner="${GITHUB_REPOSITORY%%/*}"
           repo="${GITHUB_REPOSITORY#*/}"
-          deb_url="https://${owner}.github.io/${repo}/pool/main/w/wispr-flow/${deb_name}"
+          # Hit the Worker domain directly -- the canonical apt/dnf endpoint.
+          # No GitHub Pages / github.io hop (the Worker reads metadata from
+          # gh-pages via raw.githubusercontent and 302s binaries to Releases).
+          deb_url="https://${WORKER_DOMAIN}/pool/main/w/wispr-flow/${deb_name}"
 
           deadline=$((SECONDS + 300))
           until curl -fsI --max-time 10 "$deb_url" -o /dev/null; do
@@ -291,7 +294,6 @@ jobs:
           done
 
           expected_hops=(
-            "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/${owner}/${repo}/releases/download/v${repoVer}\\+wispr${wisprVer}/"
             "https://(objects|release-assets)\\.githubusercontent\\.com/"
           )
@@ -462,7 +464,8 @@ jobs:
           rpm_name="wispr-flow-${wisprVer}-${repoVer}-1.x86_64.rpm"
           owner="${GITHUB_REPOSITORY%%/*}"
           repo="${GITHUB_REPOSITORY#*/}"
-          rpm_url="https://${owner}.github.io/${repo}/rpm/x86_64/${rpm_name}"
+          # Hit the Worker domain directly (see the APT smoke test note above).
+          rpm_url="https://${WORKER_DOMAIN}/rpm/x86_64/${rpm_name}"
 
           deadline=$((SECONDS + 300))
           until curl -fsI --max-time 10 "$rpm_url" -o /dev/null; do
@@ -472,7 +475,6 @@ jobs:
           done
 
           expected_hops=(
-            "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/${owner}/${repo}/releases/download/v${repoVer}\\+wispr${wisprVer}/"
             "https://(objects|release-assets)\\.githubusercontent\\.com/"
           )

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,25 +47,33 @@ Before the first real release:
     `update-flake-lock` use it; a tag pushed with the default `GITHUB_TOKEN`
     would **not** re-trigger the tag-driven workflow.
 
-- **`gh-pages` branch** — an orphan branch holding the published repo tree.
-  Seed it with reprepro config:
+- **`gh-pages` branch** — an orphan branch holding the published repo metadata.
+  GitHub Pages does **not** need to be enabled: the Worker reads metadata from
+  this branch via `raw.githubusercontent.com` and the smoke tests/heartbeat hit
+  `pkg.wispr-flow-linux.dev` directly. Seed it from a throwaway clone so your
+  working tree is untouched (a plain `git switch --orphan` would stage the whole
+  repo into the branch):
 
   ```bash
-  git switch --orphan gh-pages
-  mkdir -p conf
-  cat > conf/distributions <<'EOF'
+  wt=$(mktemp -d)
+  git clone -q "$(git remote get-url origin)" "$wt/ghp"
+  git -C "$wt/ghp" switch --orphan gh-pages
+  git -C "$wt/ghp" rm -rf . >/dev/null 2>&1 || true
+  mkdir -p "$wt/ghp/conf"
+  cat > "$wt/ghp/conf/distributions" <<'EOF'
   Origin: wispr-flow-linux
   Label: Wispr Flow for Linux (unofficial)
   Codename: stable
   Architectures: amd64 arm64
   Components: main
   Description: Unofficial Wispr Flow Linux packages
-  SignWith: <YOUR_GPG_KEYID>
+  SignWith: 087A3E441F1EBABFD1EBC2A21EBFB09D261977F9
   EOF
-  touch .nojekyll
-  echo "pkg.wispr-flow-linux.dev" > CNAME
-  git add -A && git commit -m "Bootstrap gh-pages repo tree" && git push -u origin gh-pages
-  git switch main
+  touch "$wt/ghp/.nojekyll"
+  git -C "$wt/ghp" add -A
+  git -C "$wt/ghp" commit -m "Bootstrap gh-pages repo tree"
+  git -C "$wt/ghp" push -u origin gh-pages
+  rm -rf "$wt"
   ```
 
 - **AUR package** — create `wispr-flow-appimage` on aur.archlinux.org. The CI

--- a/docs/learnings/apt-worker-architecture.md
+++ b/docs/learnings/apt-worker-architecture.md
@@ -41,10 +41,13 @@ filename lacks the `-<repoVer>` segment the Worker's regex needs.
 
 ## The full redirect chain (and the heartbeat)
 
-A package URL walks: Pages `301` → Worker `302` → GitHub Releases `302` → CDN
-`200`. The `apt-repo-heartbeat` workflow asserts each hop in order daily and
-checks the fetched file's size against the Release asset, opening a tracking
-issue on failure and closing it on recovery.
+A binary URL walks: `pkg.wispr-flow-linux.dev` Worker `302` → GitHub Releases
+`302` → CDN `200`. GitHub Pages is not involved — the canonical endpoint is the
+Cloudflare-fronted domain, and the Worker reads metadata from `gh-pages` via
+`raw.githubusercontent` (so the Pages feature need not be enabled). The
+`apt-repo-heartbeat` workflow asserts each hop in order daily and checks the
+fetched file's size against the Release asset, opening a tracking issue on
+failure and closing it on recovery.
 
 ## Worker-liveness gating
 


### PR DESCRIPTION
## Summary

Makes the full release cycle run green without enabling GitHub Pages. The APT/DNF
smoke tests (in `ci.yml`) and the `apt-repo-heartbeat` started at the
`*.github.io` URL, which only works if Pages is enabled with a custom-domain
redirect through Cloudflare. Since the canonical apt/dnf endpoint is the Worker
at `pkg.wispr-flow-linux.dev` (which serves metadata from `gh-pages` via
`raw.githubusercontent` and 302s binaries to Releases), these now hit the Worker
directly and drop the leading Pages→Worker hop.

## Changes

- `ci.yml`: APT + DNF smoke-test URLs → `pkg.wispr-flow-linux.dev`; 2-hop
  expected chain (Releases → CDN).
- `apt-repo-heartbeat.yml`: same repoint; removed now-unused `owner`/`repo` in
  the resolve step.
- `RELEASING.md`: fix the `gh-pages` bootstrap (throwaway clone instead of
  `git switch --orphan` + `git add -A`, which would stage the whole repo);
  note Pages/CNAME are not needed; real fingerprint filled in.
- `docs/learnings/apt-worker-architecture.md`: redirect chain updated (no Pages).

## Context

`gh-pages` is bootstrapped and the Worker is deployed + verified live
(`/conf/distributions` returns 200 through `pkg.wispr-flow-linux.dev`). With this
merged, GitHub Releases + APT + DNF + AUR are all enabled; the only remaining
switch is `PUBLISH_ENABLED=true` + a tag.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
85% AI / 15% Human
Claude: repointed the smoke tests/heartbeat, fixed the bootstrap snippet and docs, verified the Worker end-to-end.
Human: directed enabling all distribution channels and provisioned Cloudflare/DNS.
