### PR TITLE
Remove the PUBLISH_ENABLED gate; publish on any v* tag

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -1,9 +1,8 @@
 name: Build Package AMD64 (Reusable)
 
 # Builds one package format for x86_64. CI downloads the proprietary Wispr Flow
-# installer (the sensitive action gated by vars.PUBLISH_ENABLED in the caller)
-# and the pinned prebuilt clean-room helper, then runs build.sh. The .exe and
-# helper never live in the repo.
+# installer and the pinned prebuilt clean-room helper, then runs build.sh. The
+# .exe and helper never live in the repo.
 
 on:
   workflow_call:

--- a/.github/workflows/check-wispr-version.yml
+++ b/.github/workflows/check-wispr-version.yml
@@ -4,11 +4,10 @@ name: Check Wispr Flow Version
 # installer version from Wispr's "latest" redirect; when it differs from the
 # stored WISPR_FLOW_VERSION it bumps APP_VERSION (build.sh) and the Nix package
 # version, updates the variable, and pushes a v<REPO_VERSION>+wispr<VERSION> tag
-# that triggers the gated publish chain in ci.yml.
+# that triggers the publish chain in ci.yml.
 #
-# Gated behind vars.PUBLISH_ENABLED: until Wispr Flow's ToS clears, this stays
-# dormant (no upstream download, no tag). Needs GH_PAT (the default GITHUB_TOKEN
-# cannot push a tag that re-triggers tag-driven workflows).
+# Needs GH_PAT (the default GITHUB_TOKEN cannot push a tag that re-triggers
+# tag-driven workflows).
 
 on:
   schedule:
@@ -24,7 +23,6 @@ concurrency:
 
 jobs:
   check-version:
-    if: ${{ vars.PUBLISH_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,15 @@ jobs:
     name: BATS Tests
     uses: ./.github/workflows/tests.yml
 
-  # --- Gated publish chain --------------------------------------------------
-  # Everything below downloads the proprietary Wispr Flow installer and/or
-  # publishes binaries. It runs ONLY on a `v*` tag AND only when the repo
-  # variable PUBLISH_ENABLED is 'true' (held off pending Wispr Flow's ToS --
-  # see RELEASING.md). With PUBLISH_ENABLED unset, a tag push runs just the
-  # gate jobs above; flipping it to 'true' activates the whole pipeline with
-  # no code change.
+  # --- Publish chain --------------------------------------------------------
+  # Everything below downloads the proprietary Wispr Flow installer and
+  # publishes binaries. It runs on a `v*` tag push (after the gate jobs above
+  # pass); pushes to branches / PRs run only the gates. See RELEASING.md.
 
   build-amd64:
     name: Build AMD64
     needs: [test-flags, shellcheck, codespell, tests]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: read
     strategy:
@@ -68,7 +65,7 @@ jobs:
   build-arm64:
     name: Build ARM64
     needs: [test-flags, shellcheck, codespell, tests]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     permissions:
       contents: read
     strategy:
@@ -84,13 +81,13 @@ jobs:
   test-artifacts:
     name: Test Artifacts
     needs: [build-amd64]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     uses: ./.github/workflows/test-artifacts.yml
 
   release:
     name: Create Release
     needs: [build-amd64, build-arm64, test-artifacts]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -175,7 +172,7 @@ jobs:
   update-apt-repo:
     name: Update APT Repository
     needs: [release]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -239,7 +236,7 @@ jobs:
           # GitHub Release asset, so the binaries are stripped from gh-pages
           # (metadata still references the pool path; the Worker intercepts).
           # When it isn't live, keep the .debs so fetches don't 404.
-          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
+          probe_url="https://${WORKER_DOMAIN}/conf/distributions"
           if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
             echo "Worker live at ${WORKER_DOMAIN}; stripping binaries from pool"
             find pool -type f -name '*.deb' -delete
@@ -272,7 +269,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! curl -fsI --max-time 10 \
-              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+              "https://${WORKER_DOMAIN}/conf/distributions" >/dev/null; then
             echo "Worker not live; skipping smoke test"
             exit 0
           fi
@@ -322,7 +319,7 @@ jobs:
   update-dnf-repo:
     name: Update DNF Repository
     needs: [release, update-apt-repo]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -422,7 +419,7 @@ jobs:
       - name: Strip RPMs from pool (gated on Worker liveness)
         working-directory: dnf-repo
         run: |
-          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
+          probe_url="https://${WORKER_DOMAIN}/conf/distributions"
           if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
             echo "Worker live; stripping RPMs from pool (repodata retained)"
             find rpm -type f -name '*.rpm' -delete
@@ -455,7 +452,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! curl -fsI --max-time 10 \
-              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+              "https://${WORKER_DOMAIN}/conf/distributions" >/dev/null; then
             echo "Worker not live; skipping smoke test"
             exit 0
           fi
@@ -503,7 +500,7 @@ jobs:
   update-aur-repo:
     name: Update AUR Package
     needs: [release]
-    if: ${{ vars.PUBLISH_ENABLED == 'true' && startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (for PKGBUILD template)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,10 +90,9 @@ This repo's tree:
   `tests`) that run on every push/PR, plus the **tag-driven release/publish
   pipeline** (`ci.yml` build→test→release→APT→DNF→AUR, reusable
   `build-amd64`/`build-arm64`/`test-artifacts`, `check-wispr-version`,
-  `apt-repo-heartbeat`, `cleanup-runs`, `update-flake-lock`). The whole publish
-  chain is gated behind the `PUBLISH_ENABLED` repo variable (pending Wispr
-  Flow's ToS); see [`RELEASING.md`](RELEASING.md). The worker lives in its own
-  repo (`wispr-flow-linux/worker`).
+  `apt-repo-heartbeat`, `cleanup-runs`, `update-flake-lock`). The publish chain
+  runs on a `v*` tag push; see [`RELEASING.md`](RELEASING.md). The worker lives
+  in its own repo (`wispr-flow-linux/worker`).
 
 ## Code style
 
@@ -168,8 +167,7 @@ when you discover something non-obvious that would save the next contributor
 - Branch off issue numbers: `fix/123-description` or `feature/123-description`.
 - Reference issues in commits/PRs with `#123` or `Fixes #123`.
 - CI gates (`.github/workflows/ci.yml`): shellcheck, codespell, flag-parsing,
-  and bats, run on every push/PR. On a `v*` tag, and only when the
-  `PUBLISH_ENABLED` repo variable is `true`, the same workflow runs the
+  and bats, run on every push/PR. On a `v*` tag, the same workflow runs the
   build→test→release→APT/DNF/AUR publish chain. See [`RELEASING.md`](RELEASING.md).
 
 ### Attribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,7 @@ Wayland — this is the baseline).
   `pkg.wispr-flow-linux.dev`. CI resolves and downloads the proprietary
   installer itself and stages the pinned prebuilt helper
   (`scripts/setup/resolve-installer-url.sh`, `scripts/setup/fetch-helper-bin.sh`).
-  The whole chain is **gated behind the `PUBLISH_ENABLED` repo variable** (held
-  off pending Wispr Flow's ToS); see [`RELEASING.md`](RELEASING.md).
+  The chain runs on a `v*` tag push; see [`RELEASING.md`](RELEASING.md).
 - **Nix flake** (`flake.nix`, `nix/wispr-flow.nix`, `nix/fhs.nix`) packaging the
   helper and the wrapped app.
 - **Documentation tree** under `docs/` (building, configuration, troubleshooting,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,9 @@ This repo's tree:
   `tests`) that run on every push/PR, plus the **tag-driven release/publish
   pipeline** (`ci.yml` build→test→release→APT→DNF→AUR, reusable
   `build-amd64`/`build-arm64`/`test-artifacts`, `check-wispr-version`,
-  `apt-repo-heartbeat`, `cleanup-runs`, `update-flake-lock`). The whole publish
-  chain is gated behind the `PUBLISH_ENABLED` repo variable (pending Wispr
-  Flow's ToS); see [`RELEASING.md`](RELEASING.md). The worker lives in its own
-  repo (`wispr-flow-linux/worker`).
+  `apt-repo-heartbeat`, `cleanup-runs`, `update-flake-lock`). The publish chain
+  runs on a `v*` tag push; see [`RELEASING.md`](RELEASING.md). The worker lives
+  in its own repo (`wispr-flow-linux/worker`).
 
 ## Code style
 
@@ -168,8 +167,7 @@ when you discover something non-obvious that would save the next contributor
 - Branch off issue numbers: `fix/123-description` or `feature/123-description`.
 - Reference issues in commits/PRs with `#123` or `Fixes #123`.
 - CI gates (`.github/workflows/ci.yml`): shellcheck, codespell, flag-parsing,
-  and bats, run on every push/PR. On a `v*` tag, and only when the
-  `PUBLISH_ENABLED` repo variable is `true`, the same workflow runs the
+  and bats, run on every push/PR. On a `v*` tag, the same workflow runs the
   build→test→release→APT/DNF/AUR publish chain. See [`RELEASING.md`](RELEASING.md).
 
 ### Attribution

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,28 +1,16 @@
 # Releasing
 
-This project ships through tag-driven CI, gated behind the `PUBLISH_ENABLED`
-repo variable. A tag of the form `v{REPO_VERSION}+wispr{WISPR_FLOW_VERSION}` on
-`main` triggers the publish chain in [`.github/workflows/ci.yml`](.github/workflows/ci.yml),
-which builds both architectures, attaches the artifacts to a GitHub Release, and
-updates the APT, DNF, and AUR repositories.
+This project ships through tag-driven CI. A tag of the form
+`v{REPO_VERSION}+wispr{WISPR_FLOW_VERSION}` on `main` triggers the publish chain
+in [`.github/workflows/ci.yml`](.github/workflows/ci.yml), which builds both
+architectures, attaches the artifacts to a GitHub Release, and updates the APT,
+DNF, and AUR repositories. Pushes to branches/PRs run only the lint/unit gates.
 
 ```bash
 # Cut a project release once the prerequisites below are in place:
 gh variable set REPO_VERSION --body "1.0.1"
 git tag "v1.0.1+wispr$(gh variable get WISPR_FLOW_VERSION)"
 git push origin "v1.0.1+wispr$(gh variable get WISPR_FLOW_VERSION)"
-```
-
-## The gate
-
-Until Wispr Flow's ToS is settled, the publish layer is **off**. With
-`PUBLISH_ENABLED` unset (or not `true`), a `v*` tag runs only the lint/unit
-gates; the build, release, APT/DNF/AUR, and `check-wispr-version` jobs are
-skipped. Flipping `PUBLISH_ENABLED` to `true` activates the whole pipeline with
-no code change.
-
-```bash
-gh variable set PUBLISH_ENABLED --body "true"
 ```
 
 ## One-time prerequisites
@@ -33,8 +21,7 @@ Before the first real release:
 
   ```bash
   gh variable set REPO_VERSION         --body "1.0.0"   # wrapper version
-  gh variable set WISPR_FLOW_VERSION   --body "1.5.695"  # tracked upstream version
-  # PUBLISH_ENABLED stays unset until you're ready to publish.
+  gh variable set WISPR_FLOW_VERSION   --body "1.5.619"  # tracked upstream version
   ```
 
 - **Secrets**
@@ -111,8 +98,7 @@ Before the first real release:
 
 ## What CI does on a tag push
 
-After the gate jobs pass, and only when `PUBLISH_ENABLED == 'true'`, the
-[`ci.yml`](.github/workflows/ci.yml) chain:
+After the gate jobs pass, the [`ci.yml`](.github/workflows/ci.yml) chain:
 
 1. Builds deb/rpm/AppImage for amd64 and arm64 — each build resolves and
    downloads the proprietary installer and stages the pinned prebuilt helper.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,9 +30,8 @@ protocol — the contract everything else hangs off — is in
 
 ## Releasing & distribution
 
-- [**Releasing**](../RELEASING.md) — the tag scheme, the `PUBLISH_ENABLED` gate,
-  the one-time prerequisites (vars, secrets, `gh-pages`, AUR, Worker), and what
-  CI does on a tag push
+- [**Releasing**](../RELEASING.md) — the tag scheme, the one-time prerequisites
+  (vars, secrets, `gh-pages`, AUR, Worker), and what CI does on a tag push
 - [**APT/DNF + redirect Worker**](learnings/apt-worker-architecture.md) — how
   binaries reach users without hitting GitHub's 100 MB push cap
 


### PR DESCRIPTION
## Summary

Drops the `PUBLISH_ENABLED` repo-variable gate now that the publishing hold is
lifted. The build → test → release → APT/DNF/AUR chain and `check-wispr-version`
run unconditionally on a `v*` tag (after the lint/unit gates), like
claude-desktop-debian. Branch/PR pushes still run only the gates.

## Also fixes first-publish bootstrap

The "strip binaries from pool" and smoke-test worker-liveness probes used
`/dists/stable/InRelease`, which 404s before any release exists. On the **first**
publish that meant the strip was skipped and the ~150MB Electron `.deb`/`.rpm`
would be committed to `gh-pages` → GitHub's 100MB push cap → job fails. Switched
the probes to `/conf/distributions` (always present after the gh-pages
bootstrap), so the first publish strips binaries correctly and only metadata is
pushed.

## Changes

- `ci.yml`: removed `vars.PUBLISH_ENABLED` from all 7 publish-job conditions;
  probes → `/conf/distributions`.
- `check-wispr-version.yml`: removed the gate; runs on schedule/dispatch.
- `build-amd64.yml`: header comment updated.
- Docs: `RELEASING.md` (gate section removed), `CLAUDE.md`, `AGENTS.md`,
  `CHANGELOG.md`, `docs/index.md`.

## Verification

`actionlint` + `codespell` clean; no `PUBLISH_ENABLED` references remain in the
repo. The `PUBLISH_ENABLED` variable is now inert and can be deleted.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
90% AI / 10% Human
Claude: removed the gate across workflows + docs, fixed the first-publish strip-probe bootstrap bug.
Human: decided to remove the gate and proceed to full release cycles.
