### PR TITLE
feat: build native sqlite modules as pinned prebuilt assets

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install dependencies (Fedora)
         if: inputs.artifact_suffix == 'rpm'
         run: |
-          dnf install -y git findutils which curl
+          # nodejs/npm: @electron/asar extract+repack and native-module fetch.
+          dnf install -y git findutils which curl nodejs npm
 
       - name: Install FUSE for AppImageTool (Ubuntu)
         if: inputs.artifact_suffix != 'rpm'

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install dependencies (Fedora)
         if: inputs.artifact_suffix == 'rpm'
         run: |
-          dnf install -y git findutils which curl
+          # nodejs/npm: @electron/asar extract+repack and native-module fetch.
+          dnf install -y git findutils which curl nodejs npm
 
       - name: Install FUSE for AppImageTool (Ubuntu)
         if: inputs.artifact_suffix != 'rpm'

--- a/.github/workflows/build-native-modules.yml
+++ b/.github/workflows/build-native-modules.yml
@@ -1,0 +1,202 @@
+name: Build Native Modules
+
+# Produces the Linux native sqlite addons (better_sqlite3.node + node_sqlite3.node)
+# that the packaging pipeline swaps in for the app's Windows PE .node. They are
+# rebuilt from public npm + the in-repo V8 patch (NO Wispr Flow code) and shipped
+# as pinned, checksummed release assets -- mirroring the clean-room helper.
+#
+#   build    -> compile on an OLD-glibc container (manylinux_2_28, glibc 2.28
+#               floor) so the .node load on older-but-supported distros.
+#   validate -> on a normal runner, load each .node under real Electron 42 and
+#               run the encrypted-DB smoke test (ABI + round-trip + wrong-key).
+#   publish  -> only on a manual dispatch with publish=true: attach the four
+#               .node + checksums + provenance to the release named by release_tag
+#               (the tag the consumer pins in native-modules-version.txt).
+#
+# A pull_request touching the rebuild script, the pinned project, or the patch
+# runs build+validate WITHOUT publishing, so changes are proven before release.
+
+on:
+  workflow_dispatch:
+    inputs:
+      electron_version:
+        description: "Electron version to target (ABI must be 146)"
+        required: false
+        type: string
+        default: "42.3.0"
+      release_tag:
+        description: "Release tag to publish assets to (e.g. native-v1)"
+        required: false
+        type: string
+        default: ""
+      publish:
+        description: "Publish the assets to release_tag"
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - scripts/rebuild-native-modules.sh
+      - scripts/native-modules/**
+      - scripts/patches/v8-14.8-better-sqlite3-multiple-ciphers.patch
+      - .github/workflows/build-native-modules.yml
+
+permissions:
+  contents: read
+
+env:
+  NODE_VERSION: "22.22.0"
+  ELECTRON_VERSION: ${{ inputs.electron_version || '42.3.0' }}
+
+jobs:
+  #=============================================================================
+  # build -- compile on the oldest supported glibc (manylinux_2_28).
+  #=============================================================================
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            node_arch: x64
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            node_arch: arm64
+    runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install build prerequisites (patch + node)
+        run: |
+          # manylinux is AlmaLinux 8 with gcc-toolset on PATH; add patch and a
+          # pinned Node (the image ships neither npm nor a system node).
+          dnf install -y patch >/dev/null
+          curl -fsSL -o /tmp/node.tar.xz \
+            "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${{ matrix.node_arch }}.tar.xz"
+          mkdir -p /opt/node
+          tar -xJf /tmp/node.tar.xz -C /opt/node --strip-components=1
+          echo "/opt/node/bin" >> "$GITHUB_PATH"
+
+      - name: Record toolchain (glibc floor + compiler)
+        run: |
+          export PATH="/opt/node/bin:$PATH"
+          echo "node    $(node --version)"
+          echo "npm     $(npm --version)"
+          echo "glibc   $(getconf GNU_LIBC_VERSION)"
+          { c++ --version || g++ --version; } | head -1
+
+      - name: Rebuild native modules
+        run: |
+          export PATH="/opt/node/bin:$PATH"
+          chmod +x scripts/rebuild-native-modules.sh
+          # ELECTRON_BIN intentionally unset -- Electron may not start on this
+          # minimal container; the validate job runs the smoke test instead.
+          ELECTRON_VERSION="$ELECTRON_VERSION" \
+            scripts/rebuild-native-modules.sh "${{ matrix.arch }}" native-out
+
+      - name: Upload arch artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: native-modules-${{ matrix.arch }}
+          path: native-out/
+          if-no-files-found: error
+
+  #=============================================================================
+  # validate -- load under real Electron 42 + encrypted-DB smoke, on a full
+  # runner (the old-glibc container can't reliably start Electron).
+  #=============================================================================
+  validate:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+            electron_arch: x64
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+            electron_arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download arch artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: native-modules-${{ matrix.arch }}
+          path: native-out
+
+      - name: Fetch Electron ${{ env.ELECTRON_VERSION }}
+        run: |
+          zip="electron-v${ELECTRON_VERSION}-linux-${{ matrix.electron_arch }}.zip"
+          url="https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/${zip}"
+          curl -fsSL -o electron.zip "$url"
+          mkdir -p electron-dist
+          unzip -oq electron.zip -d electron-dist
+
+      - name: Verify checksums
+        run: |
+          cd native-out
+          sha256sum -c SHA256SUMS
+
+      - name: Smoke test under Electron
+        run: |
+          chmod +x scripts/native-modules/smoke-test.sh
+          scripts/native-modules/smoke-test.sh \
+            native-out "$PWD/electron-dist/electron" 146
+
+  #=============================================================================
+  # publish -- attach the four .node + checksums + provenance to release_tag.
+  # Manual dispatch with publish=true only.
+  #=============================================================================
+  publish:
+    needs: validate
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Guard -- release_tag required
+        run: |
+          [[ -n "${{ inputs.release_tag }}" ]] \
+            || { echo "::error::release_tag is required to publish"; exit 1; }
+
+      - name: Download all arch artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: artifacts
+
+      - name: Assemble arch-suffixed release assets
+        run: |
+          mkdir -p assets
+          for arch in x86_64 aarch64; do
+            src="artifacts/native-modules-${arch}"
+            [[ -d "$src" ]] || { echo "::error::missing $src"; exit 1; }
+            cp "$src/better_sqlite3.node" "assets/better_sqlite3-${arch}.node"
+            cp "$src/node_sqlite3.node"   "assets/node_sqlite3-${arch}.node"
+            cp "$src/native-modules.lock" "assets/native-modules-${arch}.lock"
+          done
+          # One combined SHA256SUMS over the arch-suffixed asset names, which is
+          # what fetch-native-bin.sh verifies the download against.
+          ( cd assets && sha256sum ./*.node > SHA256SUMS )
+          echo "--- assets ---"; ls -l assets
+
+      - name: Publish to release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ inputs.release_tag }}
+          files: assets/*
+          fail_on_unmatched_files: true
+          body: |
+            Prebuilt Linux native sqlite addons for Wispr Flow, rebuilt from
+            public npm + the in-repo V8 14.8 patch against Electron
+            ${{ env.ELECTRON_VERSION }} (ABI 146). Built on glibc 2.28
+            (manylinux_2_28). Consumed via scripts/setup/fetch-native-bin.sh,
+            pinned in native-modules-version.txt. Verify against SHA256SUMS.

--- a/docs/building.md
+++ b/docs/building.md
@@ -120,9 +120,11 @@ Here's what the staging pipeline (`scripts/build-linux.sh`) does:
    `scripts/patches/mac-gates.sh` gates the macOS "move to Applications" guard to
    `darwin` so it no-ops on Linux. See
    [scripts/README.md](../scripts/README.md) for the exact edits.
-4. **Rebuild native modules** for the Linux Electron 42 ABI (`sqlite3@5.1.7`
-   builds clean; `better-sqlite3-multiple-ciphers@12.5.0` needs the V8 14.8
-   patch — see below).
+4. **Stage native modules** for the Linux Electron 42 ABI. The app ships Windows
+   `.node`; the build swaps in pinned, prebuilt linux `better_sqlite3.node` +
+   `node_sqlite3.node` fetched and verified by
+   `scripts/setup/fetch-native-bin.sh` (with a local from-source rebuild
+   fallback — see below).
 5. **Drop `win-ca`/`crypt32`** (Windows cert store; Linux uses the system CA
    bundle); keep the Jabra Linux ELF (already cross-platform).
 6. **Stage Linux Electron 42**, repack `app.asar`, and stage the full resources
@@ -143,24 +145,38 @@ The build fetches **Electron 42.3.0** for `linux-x64` (or `linux-arm64`) from
 the upstream releases. `scripts/setup/fetch-electron-binary.js` drives this, so
 you don't pick the runtime by hand.
 
-### Native sqlite rebuild against the V8 14.8 patch
+### Native sqlite modules (prebuilt, with a local rebuild fallback)
 
 Electron 42 ships **V8 14.8 / Node 24.15**, and that combo is where this gets
 fiddly. `better-sqlite3-multiple-ciphers` **does not compile** against V8 14.8
-unpatched. You apply the clean-room compat patch before rebuilding:
+unpatched, and a binary's glibc floor is set by where it's built — so the port
+treats the two sqlite addons like the clean-room helper: built **once**, on an
+old-glibc base, and consumed as pinned, checksummed release assets.
+
+- **Producer:** `.github/workflows/build-native-modules.yml` rebuilds both
+  addons on `manylinux_2_28` (glibc 2.28 floor) per arch, validates each under
+  real Electron (ABI 146 + an encrypted-DB round-trip), and publishes them to
+  the tag in `native-modules-version.txt`. The actual build is
+  `scripts/rebuild-native-modules.sh` (lockfile-pinned `npm ci`, the V8 patch on
+  a pristine checkout, isolated electron-gyp headers).
+- **Consumer:** the build fetches the matching pair via
+  `scripts/setup/fetch-native-bin.sh`, which verifies the SHA-256 **and** the
+  provenance stamp (the asset's `patch_sha256` must equal this checkout's patch;
+  ABI must be 146) before staging. CI hard-fails if the fetch fails.
+
+For local hacking without a published asset, `build-linux.sh` Step 4 falls back
+to a from-source rebuild against your **host** glibc (fine for "does it launch
+here", not for distributable packages). To drive it directly:
 
 ```bash
-npm i better-sqlite3-multiple-ciphers@12.5.0 sqlite3@5.1.7 @electron/rebuild@4.0.4
-( cd node_modules/better-sqlite3-multiple-ciphers \
-    && patch -p1 < scripts/patches/v8-14.8-better-sqlite3-multiple-ciphers.patch )
-npx @electron/rebuild -v 42.3.0 -f \
-    -w better-sqlite3-multiple-ciphers -w sqlite3 --arch=x64
+ELECTRON_BIN=/path/to/electron \
+  scripts/rebuild-native-modules.sh x86_64 native-modules/
 ```
 
 The patch makes three version-guarded V8-API fixes (External tag, `HolderV2()`,
 `SetNativeDataProperty` ambiguity). I wrote up the why in
 [learnings/electron42-v8-sqlite.md](learnings/electron42-v8-sqlite.md) if you
-want the full story. And don't skip the rebuild to save time. The app still
+want the full story. And don't skip the modules to save time. The app still
 launches, but every DB-backed feature breaks.
 
 ### The mandatory `electron` → `wispr-flow` rename

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -362,3 +362,58 @@ runtime. **Never** use `zbus::blocking` for a service in this codebase.
 ### References
 
 - [learnings/kwin-zbus-tokio.md](learnings/kwin-zbus-tokio.md).
+
+---
+
+## D-009 — Native sqlite addons as pinned prebuilt assets, not a build-time rebuild
+
+- **Status:** Accepted
+- **Decided:** 2026-06-06
+- **Owner:** @aaddrick
+
+### Context
+
+The app ships Windows `.node` for `better-sqlite3-multiple-ciphers` + `sqlite3`;
+Linux needs them rebuilt for the Electron 42 ABI (the V8 14.8 patch from
+[D-007](#d-007--clean-room-v8-148-patch-for-better-sqlite3-multiple-ciphers)).
+The first cut only *documented* the rebuild and swapped in `.node` from a
+gitignored dir — empty in CI, so the build shipped Windows `.node` and crashed
+at startup. The obvious fix (rebuild inside each package job) is non-reproducible
+(no lockfile), a per-build supply-chain + network surface, and — decisively —
+bakes the **build runner's glibc** into the binary, so a `.node` built on a new
+CI image fails to load on older-but-supported distros.
+
+### Decision
+
+Treat the addons like the clean-room helper: build them **once**, per arch, on an
+old-glibc base, and consume them as pinned, checksummed, provenance-stamped
+release assets.
+
+- Producer: `.github/workflows/build-native-modules.yml` builds on
+  `manylinux_2_28` (glibc 2.28 floor) via `scripts/rebuild-native-modules.sh`
+  (lockfile-pinned `npm ci`, the V8 patch on a pristine checkout, isolated
+  electron-gyp headers), validates under real Electron 42 (ABI 146 + encrypted-DB
+  round-trip), and publishes to the tag in `native-modules-version.txt`.
+- Consumer: `scripts/setup/fetch-native-bin.sh` verifies SHA-256 + the
+  `native-modules.lock` provenance (asset `patch_sha256` == this checkout's
+  patch; ABI 146) before staging. CI hard-fails on fetch failure.
+
+### Rationale
+
+- Reproducible (committed `package-lock.json`, `npm ci`), and the glibc floor is
+  a deliberate choice (the build image) instead of an accident (the CI runner).
+- The provenance stamp — not ELF magic — is the trust anchor: a stale or
+  wrong-ABI `.node` is ELF-valid but provenance-mismatched, and is rejected.
+- Mirrors the established `HELPER_BIN` / `helper-version.txt` pattern.
+
+### Consequences
+
+- A new Electron/package bump means re-running the producer workflow and bumping
+  `native-modules-version.txt` — a deliberate, reviewable step.
+- `build-linux.sh` keeps a local from-source rebuild fallback (host glibc) for
+  dev convenience only; it is never used in CI.
+
+### References
+
+- [learnings/electron42-v8-sqlite.md](learnings/electron42-v8-sqlite.md),
+  [building.md](building.md#native-sqlite-modules-prebuilt-with-a-local-rebuild-fallback).

--- a/docs/learnings/electron42-v8-sqlite.md
+++ b/docs/learnings/electron42-v8-sqlite.md
@@ -35,6 +35,11 @@ need it:
 
 ## Rebuild recipe
 
+This is now automated — `scripts/rebuild-native-modules.sh` does exactly the
+steps below (lockfile-pinned `npm ci`, the patch on a pristine checkout,
+isolated electron-gyp headers so node-gyp can't grab system Node headers, then
+verifies the output). The manual equivalent:
+
 ```bash
 npm i better-sqlite3-multiple-ciphers@12.5.0 sqlite3@5.1.7 @electron/rebuild@4.0.4
 ( cd node_modules/better-sqlite3-multiple-ciphers \
@@ -46,6 +51,22 @@ npx @electron/rebuild -v 42.3.0 -f \
 The rebuilt `.node` files are staged into `app.asar.unpacked`. The patched
 12.5.0 native pairs ABI-correctly with the 12.5.0 JS wrapper that's webpacked
 into the main bundle, so the versions line up on both sides.
+
+## How it's shipped (the artifact model)
+
+Don't rebuild these in the packaging pipeline — a `.node`'s glibc floor is set
+by where it's built, so a CI-runner rebuild fails to load on older distros.
+Instead they're built **once** per arch on an old-glibc base
+(`manylinux_2_28`, glibc 2.28) by `.github/workflows/build-native-modules.yml`,
+validated under real Electron 42 (ABI 146 + an encrypted-DB round-trip via
+`scripts/native-modules/smoke-test.sh`), and published as pinned, checksummed
+release assets. The build consumes them through
+`scripts/setup/fetch-native-bin.sh`, which checks SHA-256 **and** a provenance
+stamp (`native-modules.lock`: the asset's `patch_sha256` must equal this
+checkout's patch, ABI must be 146) before staging — ELF magic alone can't tell a
+stale wrong-ABI binary from a correct one. Pinned tag:
+`native-modules-version.txt`. See
+[decisions.md D-009](../decisions.md#d-009--native-sqlite-addons-as-pinned-prebuilt-assets-not-a-build-time-rebuild).
 
 ## Validation
 

--- a/native-modules-version.txt
+++ b/native-modules-version.txt
@@ -1,0 +1,1 @@
+native-v1

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -241,36 +241,81 @@ step3_patch_bundle() {
   fi
 }
 
+# Return the 4-byte ELF magic of $1 as lowercase hex (empty on read failure).
+elf_magic() {
+  LC_ALL=C od -An -j0 -N4 -tx1 "$1" 2>/dev/null | tr -d ' \n'
+}
+
+# Resolve the linux native modules into $NATIVE_MODULES_DIR, in priority order:
+#   1. already present + linux-ELF (explicit pre-drop, pre-fetch, or a re-run).
+#   2. fetch the pinned prebuilt release asset (fetch-native-bin.sh) -- the
+#      normal path; the asset is built on an old-glibc floor and is provenance-
+#      + checksum-verified before it lands.
+#   3. fetch failed:
+#      - in CI: hard-fail. CI MUST ship the pinned prebuilt (correct glibc
+#        floor); a local rebuild here would bake the runner's newer glibc.
+#      - locally: fall back to a from-source rebuild (rebuild-native-modules.sh)
+#        against the HOST glibc -- fine for "does it launch here", not for
+#        distributable packages. Suppressed by WISPR_SKIP_NATIVE_REBUILD=1.
+# The full rationale (V8 14.8 patch, the artifact model) lives in
+# docs/learnings/electron42-v8-sqlite.md and docs/decisions.md.
+resolve_native_modules() {
+  local bsc="$NATIVE_MODULES_DIR/better_sqlite3.node"
+  local sql="$NATIVE_MODULES_DIR/node_sqlite3.node"
+
+  # 1. Already present + linux-ELF?
+  if [[ -f $bsc && -f $sql \
+        && $(elf_magic "$bsc") == '7f454c46' \
+        && $(elf_magic "$sql") == '7f454c46' ]]; then
+    auto "Using native modules already in $NATIVE_MODULES_DIR"
+    return 0
+  fi
+
+  # 2. Fetch the pinned prebuilt (the normal path).
+  auto "Fetching pinned prebuilt native modules ($ARCH)..."
+  if EXPECT_ELECTRON_VERSION="$ELECTRON_VERSION" \
+      bash "$SCRIPT_DIR/setup/fetch-native-bin.sh" "$ARCH" \
+        "$NATIVE_MODULES_DIR" >/dev/null; then
+    auto "Fetched + verified native modules into $NATIVE_MODULES_DIR"
+    return 0
+  fi
+  warn "Could not fetch pinned native modules (network? unpublished tag in"
+  warn "  native-modules-version.txt?)."
+
+  # 3a. CI: never rebuild on the runner (would bake the runner's glibc floor).
+  if [[ -n ${GITHUB_ACTIONS:-} || -n ${CI:-} ]]; then
+    warn "In CI: refusing to rebuild locally. Publish the native-modules"
+    warn "  release first (.github/workflows/build-native-modules.yml)."
+    exit 1
+  fi
+
+  # 3b. Local opt-out (offline dry-run): leave it to the Step-7 guard to fail.
+  if [[ ${WISPR_SKIP_NATIVE_REBUILD:-0} == 1 ]]; then
+    warn "WISPR_SKIP_NATIVE_REBUILD=1 -- skipping the local rebuild."
+    return 1
+  fi
+
+  # 3c. Local from-source rebuild (HOST glibc -- dev convenience only).
+  warn "Falling back to a LOCAL from-source rebuild (host glibc; the result is"
+  warn "  NOT portable to other distros -- for local testing only)."
+  if ELECTRON_VERSION="$ELECTRON_VERSION" \
+      bash "$SCRIPT_DIR/rebuild-native-modules.sh" "$ARCH" \
+        "$NATIVE_MODULES_DIR"; then
+    auto "Local rebuild produced native modules in $NATIVE_MODULES_DIR"
+    return 0
+  fi
+  warn "Local rebuild failed (missing toolchain? see rebuild-native-modules.sh)"
+  return 1
+}
+
 #===============================================================================
-# Step 4: rebuild native node modules for Linux Electron 42 ABI  [MANUAL]
+# Step 4: stage linux native node modules for the Electron 42 ABI  [AUTO]
 #===============================================================================
 step4_native_modules() {
-  say "Step 4: rebuild native modules for Linux Electron $ELECTRON_MAJOR"
-  manual "better-sqlite3-multiple-ciphers + sqlite3 ship as Windows .node binaries:"
-  echo "      $RESOURCES_SRC/app.asar.unpacked/.webpack/main/native_modules/build/Release/{better_sqlite3,node_sqlite3}.node"
-  manual "These are PE/Windows ABI; they MUST be rebuilt for linux-$ARCH against the"
-  manual "Electron $ELECTRON_VERSION ABI. Recommended approach (needs network + toolchain):"
-  cat <<DOC
-      # In a checkout that has these deps (or a temp project pinning them):
-      npx @electron/rebuild -v $ELECTRON_VERSION -f \\
-          -w better-sqlite3-multiple-ciphers -w sqlite3 --arch=$ARCH
-      # then copy the resulting *.node into the staged unpacked tree:
-      cp .../better_sqlite3.node \\
-         "$STAGE/app.asar.unpacked/.webpack/main/native_modules/build/Release/"
-      cp .../node_sqlite3.node \\
-         "$STAGE/app.asar.unpacked/.webpack/main/native_modules/build/Release/"
-DOC
-  warn "NOTE: better-sqlite3-multiple-ciphers is pinned to a yarn PATCH in package.json"
-  warn "      ('patch:better-sqlite3-multiple-ciphers@npm:12.5.0#...'). That patch is a"
-  warn "      V8 14.8 source-compat fix -- WITHOUT it the rebuild FAILS to compile against"
-  warn "      Electron $ELECTRON_VERSION (V8 14.8 / Node 24): External::Value()/New() gained"
-  warn "      mandatory pointer tags, PropertyCallbackInfo::This() was removed, and"
-  warn "      SetNativeDataProperty became ambiguous. A clean-room equivalent of the patch"
-  warn "      lives at scripts/patches/v8-14.8-better-sqlite3-multiple-ciphers.patch (replicate"
-  warn "      Wispr's yarn patch; default pointer tags = behaviour-identical). Apply it to"
-  warn "      node_modules/better-sqlite3-multiple-ciphers/src BEFORE @electron/rebuild."
-  warn "      Validated 2026-06-04: patched 12.5.0 builds + opens an encrypted DB + passes"
-  warn "      92 app migrations under Electron $ELECTRON_VERSION. sqlite3 5.1.7 builds clean (no patch)."
+  say "Step 4: stage native modules for Linux Electron $ELECTRON_MAJOR"
+
+  # Populate $NATIVE_MODULES_DIR (pinned prebuilt, else local rebuild fallback).
+  resolve_native_modules
 
   # Stage whatever unpacked tree exists so paths line up for the .node swap.
   if [[ -d "$RESOURCES_SRC/app.asar.unpacked" ]]; then
@@ -397,20 +442,58 @@ step7_helper_and_repack() {
   # Remove the Windows helper from the staged tree if it slipped in.
   rm -f "$STAGE/Release/Wispr Flow Helper.exe" 2>/dev/null || true
 
-  # 7a.5 Guard: never repack a Windows PE .node into the asar -- it would
-  #      dlopen-fail at startup ("invalid ELF header"). The native modules MUST
-  #      be linux ELF (magic = 0x7f 45 4c 46). Step 4 swaps them in; this fails
-  #      loud if that did not happen, instead of shipping a crashing package.
+  # 7a.5 Guard: never ship a Windows PE (or wrong-arch) .node -- it would
+  #      dlopen-fail at startup ("invalid ELF header"). The authoritative load
+  #      path is the staged app.asar.unpacked tree (Electron loads the addons
+  #      from there); app.asar.contents is also checked when a copy was packed.
+  #      Step 4 swaps in the linux build; this fails LOUD if that did not happen
+  #      -- including the silent case where the dir was empty and the original
+  #      Windows .node (or no .node) remained -- instead of shipping a crash.
   local nm_rel=".webpack/main/native_modules/build/Release"
-  local mod nodef magic
+  local want_machine
+  case "$ARCH" in
+    x64)   want_machine='3e00' ;;   # ELF e_machine EM_X86_64
+    arm64) want_machine='b700' ;;   # ELF e_machine EM_AARCH64
+    *)     want_machine='' ;;
+  esac
+  local mod nodef magic machine
+  # The unpacked tree is what ships + dlopens: both .node MUST be present and be
+  # a linux ELF of the target arch. Only enforced once the tree is staged (an
+  # offline dry-run that never staged resources has nothing to ship).
+  if [[ -d "$STAGE/app.asar.unpacked" ]]; then
+    for mod in better_sqlite3 node_sqlite3; do
+      nodef="$STAGE/app.asar.unpacked/$nm_rel/$mod.node"
+      if [[ ! -f "$nodef" ]]; then
+        warn "$mod.node missing from the staged app.asar.unpacked tree."
+        warn "  Step 4 did not stage a linux native module. Refusing to ship a"
+        warn "  package without it (it would crash at startup)."
+        warn "  Provide it via NATIVE_MODULES_DIR / native-modules-version.txt."
+        exit 1
+      fi
+      magic=$(elf_magic "$nodef")
+      if [[ "$magic" != '7f454c46' ]]; then
+        warn "$mod.node (app.asar.unpacked) is NOT linux ELF (magic=$magic)."
+        warn "  Refusing to ship a Windows .node that crashes at startup."
+        exit 1
+      fi
+      machine=$(LC_ALL=C od -An -j18 -N2 -tx1 "$nodef" 2>/dev/null \
+        | tr -d ' \n')
+      if [[ -n $want_machine && $machine != "$want_machine" ]]; then
+        warn "$mod.node (app.asar.unpacked) is the wrong arch (e_machine="
+        warn "  $machine, want $want_machine for $ARCH). Refusing to ship."
+        exit 1
+      fi
+    done
+  fi
+  # Defense in depth: if a .node copy was also packed into app.asar.contents,
+  # it must be a linux ELF too (absence there is fine -- .node are unpacked).
   for mod in better_sqlite3 node_sqlite3; do
     nodef="$WORK_DIR/app.asar.contents/$nm_rel/$mod.node"
     [[ -f "$nodef" ]] || continue
-    magic=$(LC_ALL=C od -An -N4 -tx1 "$nodef" 2>/dev/null | tr -d ' \n')
-    if [[ "$magic" != "7f454c46" ]]; then
+    magic=$(elf_magic "$nodef")
+    if [[ "$magic" != '7f454c46' ]]; then
       warn "$mod.node in app.asar.contents is NOT linux ELF (magic=$magic)."
       warn "  Refusing to repack a Windows .node that crashes at startup."
-      warn "  Provide linux builds via NATIVE_MODULES_DIR (see Step 4)."
       exit 1
     fi
   done

--- a/scripts/native-modules/package-lock.json
+++ b/scripts/native-modules/package-lock.json
@@ -1,0 +1,2079 @@
+{
+  "name": "wispr-flow-linux-native-modules",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wispr-flow-linux-native-modules",
+      "version": "1.0.0",
+      "license": "Unlicense",
+      "dependencies": {
+        "better-sqlite3-multiple-ciphers": "12.5.0",
+        "sqlite3": "5.1.7"
+      },
+      "devDependencies": {
+        "@electron/rebuild": "4.0.4"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.1.1",
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3-multiple-ciphers": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3-multiple-ciphers/-/better-sqlite3-multiple-ciphers-12.5.0.tgz",
+      "integrity": "sha512-bYbiV0TdCIQFqlI122+wIFnc3yXWHyz8A/026Y/YfiA3vKcC0wLnHqqociNehpFmbRSowuY3Ko8SyUhBXI9+4A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cacache/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacache/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cacache/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacache/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-cache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sqlite3/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/sqlite3/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/sqlite3/node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sqlite3/node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/sqlite3/node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/sqlite3/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sqlite3/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ssri/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ssri/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/scripts/native-modules/package.json
+++ b/scripts/native-modules/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wispr-flow-linux-native-modules",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned scratch project to rebuild Wispr Flow's native sqlite addons for the Linux Electron 42 ABI. Not published; see scripts/rebuild-native-modules.sh.",
+  "license": "Unlicense",
+  "dependencies": {
+    "better-sqlite3-multiple-ciphers": "12.5.0",
+    "sqlite3": "5.1.7"
+  },
+  "devDependencies": {
+    "@electron/rebuild": "4.0.4"
+  }
+}

--- a/scripts/native-modules/smoke-test.sh
+++ b/scripts/native-modules/smoke-test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#===============================================================================
+# smoke-test.sh -- validate rebuilt native sqlite addons against real Electron.
+#
+# Runs the addons through their ACTUAL JS wrappers under Electron (RUN_AS_NODE,
+# so no display is needed) and asserts:
+#   1. NODE_MODULE_VERSION matches the expected Electron ABI (default 146).
+#   2. better-sqlite3-multiple-ciphers opens an encrypted SQLCipher DB, round-
+#      trips a row, and REJECTS a wrong key (the encrypted data path -- the V8
+#      patch's getters all run here).
+#   3. plain sqlite3 loads.
+#
+# It installs the pinned JS wrappers (npm ci against the committed lockfile in
+# this dir, --ignore-scripts) into a throwaway dir and drops the supplied .node
+# into each wrapper's build/Release/. This works on any normal runner against
+# HARVESTED .node -- it does NOT need the rebuild's scratch tree -- so CI can
+# build the .node on an old-glibc container and validate here on a full runner.
+#
+# Usage:   smoke-test.sh <node_dir> <electron_bin> [electron_abi]
+#   node_dir       dir holding better_sqlite3.node + node_sqlite3.node
+#   electron_bin   path to an Electron binary (the target version)
+#   electron_abi   expected NODE_MODULE_VERSION (default: 146)
+#
+# Requires: node, npm, the Electron binary. Exit 0 on pass.
+#===============================================================================
+set -uo pipefail
+
+this_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'smoke-test: %s\n' "$*" >&2; exit 1; }
+
+[[ $# -ge 2 ]] || die 'usage: smoke-test.sh <node_dir> <electron_bin> [abi]'
+
+node_dir="$(cd "$1" 2>/dev/null && pwd)" || die "node_dir not found: $1"
+electron_bin="$2"
+electron_abi="${3:-146}"
+
+[[ -x $electron_bin ]] || die "electron binary not executable: $electron_bin"
+[[ -f "$node_dir/better_sqlite3.node" ]] \
+	|| die "better_sqlite3.node missing in $node_dir"
+[[ -f "$node_dir/node_sqlite3.node" ]] \
+	|| die "node_sqlite3.node missing in $node_dir"
+[[ -f "$this_dir/package-lock.json" ]] \
+	|| die "pinned package-lock.json missing in $this_dir"
+
+scratch="$(mktemp -d)" || die 'mktemp failed'
+# shellcheck disable=SC2064  # expand $scratch now, at trap-set time
+trap "rm -rf '$scratch'" EXIT
+
+log 'Installing pinned JS wrappers (npm ci, --ignore-scripts) ...'
+cp "$this_dir/package.json" "$scratch/package.json"
+cp "$this_dir/package-lock.json" "$scratch/package-lock.json"
+( cd "$scratch" && npm ci --ignore-scripts --no-audit --no-fund >&2 ) \
+	|| die 'npm ci failed'
+
+# Drop the harvested .node where each wrapper loads it.
+mkdir -p "$scratch/node_modules/better-sqlite3-multiple-ciphers/build/Release" \
+	"$scratch/node_modules/sqlite3/build/Release"
+cp "$node_dir/better_sqlite3.node" \
+	"$scratch/node_modules/better-sqlite3-multiple-ciphers/build/Release/"
+cp "$node_dir/node_sqlite3.node" \
+	"$scratch/node_modules/sqlite3/build/Release/"
+
+log "Running smoke test under $electron_bin (expect ABI $electron_abi) ..."
+(
+	cd "$scratch" \
+		&& ELECTRON_RUN_AS_NODE=1 "$electron_bin" -e "
+	const os = require('os'), fs = require('fs'), path = require('path');
+	const v = process.versions.modules;
+	if (v !== '$electron_abi') {
+		console.error('NODE_MODULE_VERSION ' + v + ' != $electron_abi');
+		process.exit(1);
+	}
+	const Database = require('better-sqlite3-multiple-ciphers');
+	require('sqlite3');   // plain sqlite3 must at least load
+	const f = path.join(os.tmpdir(), 'wispr-nm-smoke.db');
+	fs.rmSync(f, { force: true });
+	const KEY = 'correct horse battery staple';
+	let db = new Database(f);
+	db.pragma(\"cipher='sqlcipher'\");
+	db.pragma(\"key='\" + KEY + \"'\");
+	db.exec('CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT)');
+	db.prepare('INSERT INTO t(v) VALUES (?)').run('ok');
+	db.close();
+	db = new Database(f);
+	db.pragma(\"cipher='sqlcipher'\");
+	db.pragma(\"key='\" + KEY + \"'\");
+	const row = db.prepare('SELECT v FROM t WHERE id=1').get();
+	if (!row || row.v !== 'ok') throw new Error('read-back failed');
+	db.close();
+	let rejected = false;
+	try {
+		db = new Database(f);
+		db.pragma(\"cipher='sqlcipher'\");
+		db.pragma(\"key='wrong key'\");
+		db.prepare('SELECT v FROM t').get();
+	} catch (e) { rejected = true; }
+	fs.rmSync(f, { force: true });
+	if (!rejected) throw new Error('wrong key was accepted -- encryption broken');
+	console.error('smoke: ABI ' + v + ' ok; encrypted round-trip + reject ok');
+" ) || die 'smoke test FAILED (addons load but encrypted data path broken)'
+
+log 'SMOKE PASS'

--- a/scripts/rebuild-native-modules.sh
+++ b/scripts/rebuild-native-modules.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#===============================================================================
+# rebuild-native-modules.sh -- rebuild Wispr Flow's native sqlite addons for the
+# Linux Electron 42 ABI, deterministically, from public npm + the in-repo V8
+# patch. NO Wispr Flow code is involved.
+#
+# The shipped app carries WINDOWS PE .node for:
+#   better-sqlite3-multiple-ciphers   (encrypted SQLCipher DB engine)
+#   sqlite3                            (plain sqlite)
+# On Linux they must be rebuilt against Electron's V8 14.8 / Node 24 ABI (146).
+# better-sqlite3-multiple-ciphers does NOT compile against V8 14.8 unpatched;
+# the clean-room patch in scripts/patches/ is applied to a pristine checkout.
+#
+# This is the single source of rebuild truth, shared by:
+#   - .github/workflows/build-native-modules.yml (the producer -> release asset)
+#   - scripts/build-linux.sh step4               (local-dev fallback)
+#
+# It builds a throwaway, lockfile-pinned npm project (npm ci against committed
+# scripts/native-modules/package-lock.json), patches, rebuilds with an isolated
+# electron-gyp header dir (so node-gyp can NEVER pick up system Node headers),
+# harvests the two .node into <out_dir>, verifies them (ELF magic, arch, OpenSSL
+# linkage, and -- when ELECTRON_BIN is set -- the runtime ABI), and writes a
+# native-modules.lock provenance stamp + per-file .sha256.
+#
+# Usage:   rebuild-native-modules.sh <arch> <out_dir>
+#   <arch>      x86_64 | aarch64 | amd64 | arm64 | x64
+#   out_dir     where the verified .node + checksums + lock are written
+# Env:
+#   ELECTRON_VERSION   electron to target          (default: 42.3.0)
+#   ELECTRON_BIN       electron binary for the runtime ABI assertion (optional
+#                      but STRONGLY recommended; without it the ABI check is
+#                      skipped and a wrong-ABI build could slip through)
+#   REBUILD_KEEP=1     keep the scratch build dir (debugging)
+#
+# Requires: node, npm, npx, a C/C++ toolchain (cc/c++, make), python3, patch,
+#           readelf, sha256sum. Exit 0 on success.
+#===============================================================================
+set -uo pipefail
+
+#-- pinned versions (single source of truth; the lockfile pins the rest) -------
+readonly BSC_VERSION='12.5.0'        # better-sqlite3-multiple-ciphers
+readonly SQLITE_VERSION='5.1.7'      # sqlite3
+readonly REBUILD_VERSION='4.0.4'     # @electron/rebuild
+readonly ELECTRON_ABI='146'        # NODE_MODULE_VERSION (Electron 42/V8 14.8)
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+electron_version="${ELECTRON_VERSION:-42.3.0}"
+patch_file="$script_dir/patches/v8-14.8-better-sqlite3-multiple-ciphers.patch"
+pinned_dir="$script_dir/native-modules"
+
+log()  { printf '%s\n' "$*" >&2; }
+die()  { printf 'rebuild-native-modules: %s\n' "$*" >&2; exit 1; }
+
+#===============================================================================
+# arg parsing + arch normalization
+#===============================================================================
+[[ $# -ge 2 ]] || die 'usage: rebuild-native-modules.sh <arch> <out_dir>'
+
+# electron_arch feeds @electron/rebuild --arch; asset_arch names the outputs and
+# the provenance; elf_machine is the expected ELF e_machine (offset 18, LE).
+case "$1" in
+	x86_64|amd64|x64)
+		electron_arch='x64'; asset_arch='x86_64'; elf_machine='3e00' ;;
+	aarch64|arm64)
+		electron_arch='arm64'; asset_arch='aarch64'; elf_machine='b700' ;;
+	*) die "unsupported arch: $1 (want x86_64|aarch64|amd64|arm64|x64)" ;;
+esac
+
+out_dir="$2"
+mkdir -p "$out_dir" || die "cannot create out_dir: $out_dir"
+out_dir="$(cd "$out_dir" && pwd)"
+
+#===============================================================================
+# preflight: toolchain + pinned inputs
+#===============================================================================
+preflight() {
+	local missing=''
+	local tool
+	for tool in node npm npx make python3 patch readelf sha256sum; do
+		command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+	done
+	# A C++ compiler under any of the usual names.
+	if ! command -v c++ >/dev/null 2>&1 \
+		&& ! command -v g++ >/dev/null 2>&1 \
+		&& ! command -v clang++ >/dev/null 2>&1; then
+		missing="$missing c++"
+	fi
+	[[ -z $missing ]] || die "missing required tools:$missing"
+
+	[[ -f $patch_file ]] || die "V8 patch not found: $patch_file"
+	[[ -f "$pinned_dir/package.json" ]] \
+		|| die "pinned package.json not found: $pinned_dir/package.json"
+	[[ -f "$pinned_dir/package-lock.json" ]] \
+		|| die "pinned package-lock.json not found (run npm install" \
+			"--package-lock-only in $pinned_dir)"
+}
+
+#===============================================================================
+# ELF verification helpers
+#===============================================================================
+# Print the 4-byte ELF magic of $1 as lowercase hex (empty on read failure).
+elf_magic() {
+	LC_ALL=C od -An -j0 -N4 -tx1 "$1" 2>/dev/null | tr -d ' \n'
+}
+
+# Print the 2-byte e_machine of $1 (offset 18, little-endian) as hex.
+elf_machine_of() {
+	LC_ALL=C od -An -j18 -N2 -tx1 "$1" 2>/dev/null | tr -d ' \n'
+}
+
+# Fail unless $1 is a linux ELF for the expected arch, with no surprise OpenSSL
+# shared-lib dependency (better-sqlite3-multiple-ciphers vendors SQLCipher; a
+# NEEDED libcrypto/libssl would mean a runtime dep that breaks on distros with a
+# different OpenSSL soname -- and the encrypted DB is the core data path).
+verify_node() {
+	local f="$1" magic machine needed
+	[[ -f $f ]] || die "expected output missing: $f"
+
+	magic="$(elf_magic "$f")"
+	[[ $magic == '7f454c46' ]] \
+		|| die "$f is not a linux ELF (magic=$magic)"
+
+	machine="$(elf_machine_of "$f")"
+	[[ $machine == "$elf_machine" ]] \
+		|| die "$f e_machine=$machine, expected $elf_machine ($asset_arch)"
+
+	needed="$(readelf -d "$f" 2>/dev/null \
+		| grep -iE 'NEEDED.*(libcrypto|libssl)')"
+	if [[ -n $needed ]]; then
+		die "$f dynamically links OpenSSL ($needed) -- want a vendored/static" \
+			"SQLCipher build; this would break on distros with a different" \
+			"libcrypto soname. Fix the build flags, do not ship this."
+	fi
+}
+
+# Validate the harvested addons under Electron via the shared smoke test (ABI +
+# encrypted-DB round-trip + wrong-key reject). Skipped (loud warning) when
+# ELECTRON_BIN is unset -- in CI the producer runs the same smoke test in a
+# separate job on a full runner, since Electron may not start on the minimal
+# old-glibc build container.
+verify_smoke() {
+	if [[ -z ${ELECTRON_BIN:-} ]]; then
+		log 'WARNING: ELECTRON_BIN unset -- skipping the ABI + encrypted-DB smoke'
+		log '  test. A wrong-ABI build (e.g. compiled against system Node headers)'
+		log '  will NOT be caught here. Set ELECTRON_BIN to the staged Electron 42.'
+		return 0
+	fi
+	bash "$pinned_dir/smoke-test.sh" "$out_dir" "$ELECTRON_BIN" "$ELECTRON_ABI" \
+		|| die 'smoke test failed (see above)'
+}
+
+#===============================================================================
+# the rebuild
+#===============================================================================
+main() {
+	preflight
+
+	local scratch
+	scratch="$(mktemp -d)" || die 'mktemp failed'
+	if [[ ${REBUILD_KEEP:-0} != 1 ]]; then
+		# shellcheck disable=SC2064  # expand $scratch now, at trap-set time
+		trap "rm -rf '$scratch'" EXIT
+	else
+		log "REBUILD_KEEP=1 -- scratch dir retained: $scratch"
+	fi
+
+	# Pristine, lockfile-pinned install. --ignore-scripts so the package's own
+	# install-time node-gyp (which would target the HOST Node ABI) never runs;
+	# @electron/rebuild below is the only compile, against Electron's ABI.
+	log "Installing pinned deps (npm ci, --ignore-scripts) ..."
+	cp "$pinned_dir/package.json" "$scratch/package.json"
+	cp "$pinned_dir/package-lock.json" "$scratch/package-lock.json"
+	( cd "$scratch" \
+		&& npm ci --ignore-scripts --no-audit --no-fund >&2 ) \
+		|| die 'npm ci failed (network? lockfile drift?)'
+
+	local bsc_src="$scratch/node_modules/better-sqlite3-multiple-ciphers"
+	[[ -d "$bsc_src/src" ]] \
+		|| die "patched source tree absent: $bsc_src/src"
+
+	# Apply the V8 14.8 patch to the PRISTINE checkout. --forward skips an
+	# already-applied patch cleanly; --fuzz=0 refuses an imperfect match so a
+	# drifted patch hard-fails instead of landing a half-correct build.
+	log 'Applying V8 14.8 patch to better-sqlite3-multiple-ciphers ...'
+	( cd "$bsc_src" \
+		&& patch -p1 --forward --fuzz=0 < "$patch_file" >&2 ) \
+		|| die 'V8 patch did not apply cleanly (drift vs pinned version?)'
+
+	# Rebuild against Electron's headers in an ISOLATED gyp dir, so a stray
+	# ~/.electron-gyp / ~/.node-gyp / env cannot feed wrong (system Node)
+	# headers -- the patch is V8_MAJOR_VERSION-guarded and would compile clean
+	# against the wrong V8, masking an ABI-broken binary.
+	log "Rebuilding for Electron $electron_version (linux-$electron_arch) ..."
+	(
+		cd "$scratch" \
+			&& export npm_config_runtime='electron' \
+			&& export npm_config_target="$electron_version" \
+			&& export npm_config_disturl='https://electronjs.org/headers' \
+			&& export npm_config_arch="$electron_arch" \
+			&& export npm_config_devdir="$scratch/.electron-gyp" \
+			&& npx --yes @electron/rebuild -v "$electron_version" -f \
+				-w better-sqlite3-multiple-ciphers -w sqlite3 \
+				--arch="$electron_arch" >&2
+	) || die '@electron/rebuild failed'
+
+	# Harvest -- note the two packages emit DIFFERENT .node names.
+	cp "$bsc_src/build/Release/better_sqlite3.node" \
+		"$out_dir/better_sqlite3.node" \
+		|| die 'better_sqlite3.node not produced'
+	cp "$scratch/node_modules/sqlite3/build/Release/node_sqlite3.node" \
+		"$out_dir/node_sqlite3.node" \
+		|| die 'node_sqlite3.node not produced'
+
+	# Verify what we produced before anyone trusts it.
+	log 'Verifying outputs (ELF, arch, OpenSSL linkage) ...'
+	verify_node "$out_dir/better_sqlite3.node"
+	verify_node "$out_dir/node_sqlite3.node"
+	verify_smoke
+
+	# Checksums (consumer verifies these against the release assets).
+	( cd "$out_dir" \
+		&& sha256sum better_sqlite3.node node_sqlite3.node \
+			> SHA256SUMS ) \
+		|| die 'sha256sum failed'
+
+	# Provenance stamp -- the consumer skips a rebuild/refetch ONLY when this
+	# matches the build's (electron, pkg, patch) tuple. ELF magic alone cannot
+	# tell a stale wrong-ABI binary from a correct one; this can.
+	local patch_sha glibc gcc bsc_sha sqlite_sha
+	patch_sha="$(sha256sum "$patch_file" | cut -d' ' -f1)"
+	glibc="$(getconf GNU_LIBC_VERSION 2>/dev/null | awk '{print $NF}')"
+	glibc="${glibc:-unknown}"
+	gcc="$( { c++ --version || g++ --version; } 2>/dev/null | head -1)"
+	bsc_sha="$(sha256sum "$out_dir/better_sqlite3.node" | cut -d' ' -f1)"
+	sqlite_sha="$(sha256sum "$out_dir/node_sqlite3.node" | cut -d' ' -f1)"
+
+	cat > "$out_dir/native-modules.lock" <<JSON
+{
+	"electron_version": "$electron_version",
+	"abi": "$ELECTRON_ABI",
+	"arch": "$asset_arch",
+	"packages": {
+		"better-sqlite3-multiple-ciphers": "$BSC_VERSION",
+		"sqlite3": "$SQLITE_VERSION",
+		"@electron/rebuild": "$REBUILD_VERSION"
+	},
+	"patch_sha256": "$patch_sha",
+	"better_sqlite3_sha256": "$bsc_sha",
+	"node_sqlite3_sha256": "$sqlite_sha",
+	"build_glibc": "$glibc",
+	"build_cc": "$gcc"
+}
+JSON
+
+	log "Done. Wrote to $out_dir :"
+	log '  better_sqlite3.node  node_sqlite3.node  SHA256SUMS  native-modules.lock'
+}
+
+main "$@"

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -19,8 +19,12 @@
 #   rpmbuild   (rpm-build)    -- only for --build rpm
 #   dpkg-deb   (dpkg-dev/dpkg)-- only for --build deb
 #
-# NOTE: node-pty / electron-rebuild devDeps are NOT system packages here; the
-# native rebuild is handled inside build-linux.sh's documented flow.
+# NOTE: the native sqlite addons are fetched as pinned, provenance-verified
+# prebuilt assets (scripts/setup/fetch-native-bin.sh), so no C/C++ toolchain is
+# required for the normal build. Only the OPTIONAL local from-source rebuild
+# fallback (build-linux.sh Step 4 -> rebuild-native-modules.sh) needs a compiler
+# + make + python3; it reports any missing tool itself, so they are not forced
+# system deps here.
 #===============================================================================
 
 check_dependencies() {

--- a/scripts/setup/fetch-native-bin.sh
+++ b/scripts/setup/fetch-native-bin.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#===============================================================================
+# fetch-native-bin.sh -- download the pinned prebuilt Linux native sqlite addons
+# for a target arch, verify them, and print their directory (for the
+# NATIVE_MODULES_DIR env var build-linux.sh consumes).
+#
+# The addons (better_sqlite3.node + node_sqlite3.node) are rebuilt from public
+# npm + the in-repo V8 patch by .github/workflows/build-native-modules.yml and
+# published as release assets pinned in native-modules-version.txt. Each release
+# ships, per arch:
+#   better_sqlite3-x86_64.node   node_sqlite3-x86_64.node
+#   better_sqlite3-aarch64.node  node_sqlite3-aarch64.node
+#   native-modules-<arch>.lock   (provenance)   SHA256SUMS (over all .node)
+#
+# This stages the matching pair into <dest>/{better_sqlite3,node_sqlite3}.node
+# (the plain names the Step-4 swap expects), AFTER:
+#   1. sha256 verification against the release's SHA256SUMS, and
+#   2. provenance verification -- the asset's native-modules.lock patch_sha256
+#      MUST equal this checkout's patch file, and its ABI must be 146. This is
+#      what makes the binary trustworthy: ELF magic alone cannot tell a stale,
+#      wrong-ABI, or wrong-patch build from a correct one.
+# It prints the dest dir to stdout (diagnostics go to stderr). CI sets
+# NATIVE_MODULES_DIR="$(scripts/setup/fetch-native-bin.sh <arch>)" before build.
+#
+# Usage:   fetch-native-bin.sh <arch> [dest_dir]
+#   <arch>      x86_64 | aarch64 | amd64 | arm64 | x64
+#   dest_dir    where to place the binaries (default: <repo>/native-modules)
+# Env:
+#   EXPECT_ELECTRON_VERSION   if set, the lock's electron_version must match it
+#
+# Requires: gh (authenticated) OR curl; sha256sum. Exit 0 on success.
+#===============================================================================
+set -uo pipefail
+
+readonly NATIVE_REPO='wispr-flow-linux/wispr-flow-linux'
+readonly EXPECT_ABI='146'
+
+log() { printf '%s\n' "$*" >&2; }
+die() { printf 'fetch-native-bin: %s\n' "$*" >&2; exit 1; }
+
+[[ $# -ge 1 ]] || die 'usage: fetch-native-bin.sh <arch> [dest_dir]'
+
+case "$1" in
+	x86_64|amd64|x64) asset_arch='x86_64' ;;
+	aarch64|arm64)    asset_arch='aarch64' ;;
+	*) die "unsupported arch: $1 (want x86_64|aarch64|amd64|arm64|x64)" ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+dest_dir="${2:-$repo_root/native-modules}"
+
+version_file="$repo_root/native-modules-version.txt"
+[[ -f $version_file ]] || die "native-modules-version.txt not found"
+tag="$(tr -d '[:space:]' < "$version_file")"
+[[ -n $tag ]] || die 'native-modules-version.txt is empty'
+
+patch_rel='scripts/patches/v8-14.8-better-sqlite3-multiple-ciphers.patch'
+patch_file="$repo_root/$patch_rel"
+[[ -f $patch_file ]] || die "patch file not found: $patch_file"
+
+command -v sha256sum >/dev/null 2>&1 || die 'sha256sum is required'
+
+mkdir -p "$dest_dir" || die "cannot create ${dest_dir}"
+dest_dir="$(cd "$dest_dir" && pwd)"
+
+bsc_asset="better_sqlite3-${asset_arch}.node"
+sqlite_asset="node_sqlite3-${asset_arch}.node"
+lock_asset="native-modules-${asset_arch}.lock"
+tmp_dir="$(mktemp -d)" || die 'mktemp failed'
+# shellcheck disable=SC2064  # expand $tmp_dir now, at trap-set time
+trap "rm -rf '$tmp_dir'" EXIT
+
+log "Fetching ${asset_arch} native modules from ${NATIVE_REPO}@${tag} ..."
+
+# Download an asset by name into $tmp_dir: prefer gh (auth/rate limits), fall
+# back to curl on absence OR failure (the release is public). Mirrors
+# fetch-helper-bin.sh.
+fetch_asset() {
+	local name="$1" url
+	url="https://github.com/${NATIVE_REPO}/releases/download/${tag}/${name}"
+	if command -v gh >/dev/null 2>&1; then
+		if gh release download "$tag" --repo "$NATIVE_REPO" \
+			--pattern "$name" --dir "$tmp_dir" --clobber >&2; then
+			return 0
+		fi
+		log "gh download of ${name} failed; falling back to curl"
+	fi
+	command -v curl >/dev/null 2>&1 \
+		|| die "gh unavailable/failed and curl is not installed"
+	curl -fSL -o "$tmp_dir/$name" "$url" \
+		|| die "download failed: ${url}"
+}
+
+fetch_asset "$bsc_asset"
+fetch_asset "$sqlite_asset"
+fetch_asset "$lock_asset"
+fetch_asset 'SHA256SUMS'
+
+# 1. Checksum verification -- check only this arch's two lines so other-arch
+#    assets we did not download do not fail the -c run.
+log 'Verifying checksums ...'
+grep -E "  \./($bsc_asset|$sqlite_asset)\$" "$tmp_dir/SHA256SUMS" \
+	> "$tmp_dir/SHA256SUMS.arch" \
+	|| die "SHA256SUMS has no entries for ${asset_arch}"
+( cd "$tmp_dir" && sha256sum -c SHA256SUMS.arch >&2 ) \
+	|| die 'checksum verification FAILED'
+
+# 2. Provenance verification -- read a "key": "value" string from the lock.
+lock_field() {
+	grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$tmp_dir/$lock_asset" \
+		| head -1 | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/'
+}
+log 'Verifying provenance (patch + ABI) ...'
+asset_patch="$(lock_field patch_sha256)"
+repo_patch="$(sha256sum "$patch_file" | cut -d' ' -f1)"
+[[ -n $asset_patch ]] || die 'lock has no patch_sha256'
+[[ $asset_patch == "$repo_patch" ]] \
+	|| die "patch mismatch: asset built with ${asset_patch}, this checkout has" \
+		"${repo_patch} -- republish native modules for the current patch"
+asset_abi="$(lock_field abi)"
+[[ $asset_abi == "$EXPECT_ABI" ]] \
+	|| die "ABI mismatch: asset abi=${asset_abi}, expected ${EXPECT_ABI}"
+if [[ -n ${EXPECT_ELECTRON_VERSION:-} ]]; then
+	asset_ev="$(lock_field electron_version)"
+	[[ $asset_ev == "$EXPECT_ELECTRON_VERSION" ]] \
+		|| die "electron mismatch: asset=${asset_ev}," \
+			"expected ${EXPECT_ELECTRON_VERSION}"
+fi
+
+# Stage under the plain names the Step-4 swap reads, plus the provenance lock.
+cp "$tmp_dir/$bsc_asset" "$dest_dir/better_sqlite3.node" \
+	|| die 'failed to stage better_sqlite3.node'
+cp "$tmp_dir/$sqlite_asset" "$dest_dir/node_sqlite3.node" \
+	|| die 'failed to stage node_sqlite3.node'
+cp "$tmp_dir/$lock_asset" "$dest_dir/native-modules.lock" || true
+
+log "Staged native modules at ${dest_dir}"
+printf '%s\n' "$dest_dir"

--- a/tests/test-artifact-common.sh
+++ b/tests/test-artifact-common.sh
@@ -51,6 +51,23 @@ assert_setuid() {
 	fi
 }
 
+# Assert $1 is a linux ELF (magic 7f 45 4c 46). Catches a Windows PE .node that
+# would dlopen-fail at startup ("invalid ELF header") -- the exact regression the
+# native-module staging guards against.
+assert_linux_elf() {
+	local f="$1" magic
+	if [[ ! -f $f ]]; then
+		fail "Not an ELF (missing): $f"
+		return
+	fi
+	magic=$(LC_ALL=C od -An -j0 -N4 -tx1 "$f" 2>/dev/null | tr -d ' \n')
+	if [[ $magic == '7f454c46' ]]; then
+		pass "Linux ELF: $f"
+	else
+		fail "Not a linux ELF (magic=$magic, want 7f454c46): $f"
+	fi
+}
+
 assert_contains() {
 	local file="$1" pattern="$2" desc="${3:-}"
 	if grep -q "$pattern" "$file" 2>/dev/null; then
@@ -90,11 +107,15 @@ validate_app_contents() {
 	assert_file_exists "$resources_dir/app.asar"
 	assert_dir_exists "$resources_dir/app.asar.unpacked"
 
-	# Unpacked native modules: better-sqlite3 (rebuilt for Electron 42's
-	# V8 14.8) lives under the unpacked .webpack tree and must ship as a
-	# real file (asar can't load a native .node from inside the archive).
-	assert_file_exists \
-		"$resources_dir/app.asar.unpacked/.webpack/main/native_modules/build/Release/better_sqlite3.node"
+	# Unpacked native modules: better-sqlite3 + sqlite3 (rebuilt for Electron
+	# 42's V8 14.8) live under the unpacked .webpack tree and must ship as real
+	# files (asar can't load a native .node from inside the archive) AND as linux
+	# ELF -- the shipped app dlopens them at startup, so a Windows .node here
+	# crashes before any window opens.
+	local nm_rel
+	nm_rel="app.asar.unpacked/.webpack/main/native_modules/build/Release"
+	assert_linux_elf "$resources_dir/$nm_rel/better_sqlite3.node"
+	assert_linux_elf "$resources_dir/$nm_rel/node_sqlite3.node"
 
 	# The clean-room Rust Linux helper the patched resolver points at.
 	local helper="$resources_dir/Release/wispr-flow-linux-helper"


### PR DESCRIPTION
## Problem

The packaging build needs `better-sqlite3-multiple-ciphers` + `sqlite3` rebuilt for the Linux Electron 42 ABI (the V8 14.8 patch, [D-007](docs/decisions.md)). The prior `step4_native_modules()` only **documented** the rebuild and swapped in `.node` from a gitignored dir — empty in CI, so the build shipped the app's **Windows `.node`** and crashed at startup (`invalid ELF header`). The step-7 ELF guard checked `app.asar.contents` (where `.node` are legitimately absent — they're unpacked), so it passed **vacuously**.

## Approach (D-009)

Treat the addons like the clean-room helper: build them **once**, per arch, on an **old-glibc base**, and consume them as pinned, checksummed, **provenance-stamped** release assets. Chosen over an in-pipeline rebuild after a contrarian review flagged that a CI-runner rebuild is non-reproducible and bakes the runner's glibc into the binary (fails on older distros).

### Producer
- `scripts/rebuild-native-modules.sh` — lockfile-pinned `npm ci`, V8 patch on a **pristine** checkout (`--forward --fuzz=0`), **isolated electron-gyp headers** so node-gyp can't grab system Node headers, output verified (ELF magic + `e_machine` arch + no OpenSSL `NEEDED`).
- `scripts/native-modules/{package.json,package-lock.json}` — pinned scratch project (12.5.0 / 5.1.7 / @electron/rebuild 4.0.4), real lockfile (173 pkgs, integrity-hashed).
- `scripts/native-modules/smoke-test.sh` — under real Electron: asserts **ABI 146**, opens an encrypted SQLCipher DB, round-trips a row, **rejects a wrong key**.
- `.github/workflows/build-native-modules.yml` — build on **`manylinux_2_28`** (glibc 2.28 floor) per arch → validate under Electron 42 on full runners → publish to `native-modules-version.txt`'s tag on manual dispatch (PRs build+validate without publishing).

### Consumer
- `scripts/setup/fetch-native-bin.sh` — mirrors `fetch-helper-bin.sh`; verifies **SHA-256 + provenance** (asset `patch_sha256` == this checkout's patch, ABI 146) before staging.
- `native-modules-version.txt` → `native-v1`.
- `build-linux.sh` Step 4 resolve chain: present → fetch → (**CI: hard-fail** / local: from-source rebuild fallback). Step-7 guard rewritten to verify the **authoritative `app.asar.unpacked` tree**, hard-failing on absent / non-ELF / wrong-arch.
- CI: `fedora:42` rpm container now installs `nodejs npm` (also fixes a latent `@electron/asar` bug).

## Validation (local, against real Electron 42.3.0)
Rebuild ran end-to-end: patch applied clean, both addons built, **ABI 146 / V8 14.8 confirmed**, SQLCipher **vendored static** (no `libcrypto` NEEDED), encrypted round-trip + wrong-key reject passed. Resolve-chain tiers tested (present/opt-out/CI-hard-fail). Publish→fetch verification simulated offline (checksum + provenance match). Gates: shellcheck, actionlint, codespell clean; `--test-flags` OK; all 84 bats pass.

## Note on the gate
The `native-v1` release must be published (run **Build Native Modules**, `publish=true`) before the main pipeline can fetch it — until then CI hard-fails by design. First producer run also validates that `manylinux_2_28`'s gcc-toolset compiles the patched addon (local validation was on gcc 15 / glibc 2.42).

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>
90% AI / 10% Human
Claude: design, contrarian-driven redesign, all implementation, local end-to-end validation against Electron 42.
Human: direction, ran contrarian, chose the artifact-model scope, authorized PR/merge/release.