### PR TITLE
fix(patches): re-audit linux-window-frame for Wispr 1.5.695 (+ Node 24 action bumps)

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install dependencies (Fedora)
         if: inputs.artifact_suffix == 'rpm'
@@ -106,7 +106,7 @@ jobs:
           ./scripts/verify-patches.sh "$asar_path"
 
       - name: Upload AMD64 Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: package-amd64-${{ inputs.artifact_suffix }}
           path: out/*

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install dependencies (Fedora)
         if: inputs.artifact_suffix == 'rpm'
@@ -84,7 +84,7 @@ jobs:
             -exec cp -v {} out/ \;
 
       - name: Upload ARM64 Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: package-arm64-${{ inputs.artifact_suffix }}
           path: out/*

--- a/.github/workflows/build-native-modules.yml
+++ b/.github/workflows/build-native-modules.yml
@@ -69,7 +69,7 @@ jobs:
     container: ${{ matrix.container }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install build prerequisites (patch + node)
         run: |
@@ -100,7 +100,7 @@ jobs:
             scripts/rebuild-native-modules.sh "${{ matrix.arch }}" native-out
 
       - name: Upload arch artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: native-modules-${{ matrix.arch }}
           path: native-out/
@@ -125,10 +125,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download arch artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: native-modules-${{ matrix.arch }}
           path: native-out
@@ -169,7 +169,7 @@ jobs:
             || { echo "::error::release_tag is required to publish"; exit 1; }
 
       - name: Download all arch artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: artifacts
 
@@ -189,7 +189,7 @@ jobs:
           echo "--- assets ---"; ls -l assets
 
       - name: Publish to release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ inputs.release_tag }}
           files: assets/*

--- a/.github/workflows/check-wispr-version.yml
+++ b/.github/workflows/check-wispr-version.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout repository (for git history)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Download all build artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           path: artifacts/
           merge-multiple: true
@@ -164,7 +164,7 @@ jobs:
           cat notes/summary.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: artifacts/**/*
           body_path: notes/summary.md
@@ -180,19 +180,19 @@ jobs:
       WORKER_DOMAIN: pkg.wispr-flow-linux.dev
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: gh-pages
           path: apt-repo
 
       - name: Download AMD64 deb artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: package-amd64-deb
           path: incoming/
 
       - name: Download ARM64 deb artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: package-arm64-deb
           path: incoming/
@@ -327,19 +327,19 @@ jobs:
       WORKER_DOMAIN: pkg.wispr-flow-linux.dev
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: gh-pages
           path: dnf-repo
 
       - name: Download AMD64 rpm artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: package-amd64-rpm
           path: incoming/
 
       - name: Download ARM64 rpm artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: package-arm64-rpm
           path: incoming/
@@ -504,10 +504,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (for PKGBUILD template)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download AMD64 AppImage artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: package-amd64-appimage
           path: artifacts/

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: ${{ matrix.artifact }}
           path: artifacts/

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           token: ${{ secrets.GH_PAT }}
 

--- a/docs/learnings/patching-minified-js.md
+++ b/docs/learnings/patching-minified-js.md
@@ -161,17 +161,24 @@ Two patterns from the suite:
   service"`, then captures the surrounding minified logger identifier
   (`([\w$]+)\(\)\.info\(…)`) as the actual target. Stable literal locates the
   site; the dynamic capture supplies the churning name.
-- **Literal-shape anchor + captured var.** `linux-window-frame.sh:115` pins the
-  window-config site on the `titleBarStyle:"hiddenInset"` / `"win32"===
-  process.platform` / `Object.assign(<var>,{titleBarStyle:"hidden",…})` literal
-  shape and captures only `<var>` as `[\w$]+`.
+- **Literal-shape anchor + captured var.** `linux-window-frame.sh` pins the
+  window-config site on the `"win32"===process.platform` /
+  `Object.assign(<var>,{titleBarStyle:"hidden",autoHideMenuBar:!0})` literal
+  shape and captures only `<var>` as `[\w$]+`. (It used to also anchor on a
+  `titleBarStyle:"hiddenInset"` mac branch; 1.5.695 dropped `hiddenInset`, so
+  the anchor was narrowed to the still-unique win32-predicate + hidden-assign
+  pair — see the re-audit note below.)
 
 The lesson is about finding stable points to anchor on, not about what gets
 patched. Even literal anchors aren't immortal: `linux-window-frame.sh` no-oped
-on Wispr 1.5.695 because the window-config *shape* itself moved — which is why a
-version bump means a re-audit ([platform-gates.md](platform-gates.md)), and why
-the count assertion below turns that no-op into a loud failure instead of a
-silent one.
+on Wispr 1.5.695 because the window-config *shape* itself moved — the mac branch
+dropped `titleBarStyle:"hiddenInset"`, and the lone surviving three-way win32
+site shifted from the Hub window (now a two-way switch whose else branch already
+frames Linux) to the meeting_recorder window. The re-audit narrowed the anchor
+to the win32-predicate + hidden-title-bar `Object.assign` pair (still unique).
+This is why a version bump means a re-audit ([platform-gates.md](platform-gates.md)),
+and why the count assertion below turns that no-op into a loud failure instead of
+a silent one.
 
 ## Multi-site coordinated patches: surface partial application
 

--- a/docs/learnings/platform-gates.md
+++ b/docs/learnings/platform-gates.md
@@ -149,7 +149,7 @@ backup, `node --check`s the result, and is idempotent (re-run = byte-identical).
 | Gap | Patch | Marker |
 |---|---|---|
 | Menu offset + invisible window controls (remap `<html>` class linux→win32) | [`linux-renderer-chrome.sh`](../../scripts/patches/linux-renderer-chrome.sh) | `WISPR_LINUX_WIN32_CHROME` |
-| Settings/Hub window fell to default framed + visible menu bar → make it frameless like win32 | [`linux-window-frame.sh`](../../scripts/patches/linux-window-frame.sh) | `WISPR_LINUX_FRAMELESS` |
+| Chrome window fell to default framed + visible menu bar → make it frameless like win32 (1.5.695: the meeting_recorder window; the Hub/scratchpad windows now self-frame Linux via a two-way else branch) | [`linux-window-frame.sh`](../../scripts/patches/linux-window-frame.sh) | `WISPR_LINUX_FRAMELESS` |
 | Fresh installs seeded macOS `fn`/⌘ shortcut defaults + skipped the onboarding Permissions step → widen each renderer's `isWindows` **bind** to also be true on linux (bridge stays honest) | [`linux-renderer-treat-as-windows.sh`](../../scripts/patches/linux-renderer-treat-as-windows.sh) | `WISPR_LINUX_RENDERER_ISWIN` |
 | Cold-start `wispr-flow:` deep links dropped (parse was win32-only) → widen the argv-parse guard | [`linux-deeplink.sh`](../../scripts/patches/linux-deeplink.sh) | `WISPR_LINUX_DEEPLINK` |
 

--- a/scripts/patches/linux-window-frame.sh
+++ b/scripts/patches/linux-window-frame.sh
@@ -6,20 +6,31 @@
 #
 # WHY THIS PATCH EXISTS
 # ---------------------
-# Several BrowserWindow configs in the main bundle pick a title-bar / frame
+# Some BrowserWindow configs in the main bundle pick a title-bar / frame
 # treatment with a THREE-WAY platform switch of the shape:
 #
-#   isMac ? Object.assign(t,{titleBarStyle:"hiddenInset"})
+#   isMac ? Object.assign(t,{frame:!1,titleBarStyle:"hidden",
+#                            trafficLightPosition:{x:1e4,y:10},...})
 #         : "win32"===process.platform &&
 #             Object.assign(t,{titleBarStyle:"hidden",autoHideMenuBar:!0});
 #
-# macOS gets the inset traffic-light title bar; Windows gets a hidden title bar
-# (custom in-window chrome) with the menu bar suppressed. Linux matches NEITHER
-# predicate, so `t` is left untouched and Electron renders its platform DEFAULT:
-# a full native title bar + a visible menu bar. That clashes with the renderer
-# CSS patch that makes Linux adopt the `.win32` chrome (a custom title bar with
-# in-window minimize/maximize/close controls): those controls only render
-# correctly inside a frameless / hidden-title-bar window, exactly like Windows.
+# macOS gets a frameless window with a hidden title bar and the traffic lights
+# parked offscreen; Windows gets a hidden title bar (custom in-window chrome)
+# with the menu bar suppressed. Linux matches NEITHER predicate, so `t` is left
+# untouched and Electron renders its platform DEFAULT: a full native title bar +
+# a visible menu bar. That clashes with the renderer CSS patch that makes Linux
+# adopt the `.win32` chrome (a custom title bar with in-window
+# minimize/maximize/close controls): those controls only render correctly inside
+# a frameless / hidden-title-bar window, exactly like Windows.
+#
+# As of Wispr Flow 1.5.695 this is the meeting_recorder window. The other chrome
+# windows no longer have this gap: the Flow Hub and scratchpad windows now use a
+# TWO-WAY `isMac ? {frame:!1,...} : {frame:!1,autoHideMenuBar:!0}` switch whose
+# else branch already gives Linux a frameless window, and the overlay / status /
+# contextMenu / calendar_reminder windows set `frame:!1` unconditionally. Earlier
+# Wispr versions keyed the mac branch on `titleBarStyle:"hiddenInset"`; that
+# disappeared in the 1.5.695 refactor (which is why the old anchor no-oped and
+# verify-patches.sh failed on the absent WISPR_LINUX_FRAMELESS marker).
 #
 # THE PATCH (surgical, widen ONE predicate at the window-config site)
 # -------------------------------------------------------------------
@@ -52,12 +63,17 @@
 # Anchor (unique in the bundle), keyed on stable developer string literals --
 # NOT on minified symbols (the platform flags `tD`/`H8` and the config var churn
 # every release):
-#   titleBarStyle:"hiddenInset"})  +  "win32"===process.platform  +
-#   Object.assign(<var>,{titleBarStyle:"hidden",autoHideMenuBar:!0})
-# All three literals must be adjacent, which uniquely identifies the
-# Settings/Hub window-config ternary (the only window config of this shape;
-# the other hidden-title-bar windows are overlays that already set frame:!1
-# unconditionally and so are already frameless on Linux).
+#   "win32"===process.platform  +
+#   &&Object.assign(<var>,{titleBarStyle:"hidden",autoHideMenuBar:!0})
+# These two literals adjacent uniquely identify the meeting_recorder
+# window-config ternary -- the only window config of this shape (the Hub and
+# scratchpad windows moved to a two-way switch whose else branch already gives
+# Linux frame:!1, and the overlay/status/contextMenu/calendar_reminder windows
+# set frame:!1 unconditionally, so all of those are already frameless on Linux).
+# We no longer anchor on the mac branch: it churns (it dropped "hiddenInset" in
+# 1.5.695), and the win32-predicate + hidden-title-bar Object.assign pair is
+# already unique on its own. The EXPECTED count assertion below fails loudly if
+# upstream ever reintroduces that pair at a second site.
 #
 # Usage: patch-linux-window-frame.sh <path-to-.webpack/main/index.js>
 #===============================================================================
@@ -99,28 +115,27 @@ path, marker = sys.argv[1], sys.argv[2]
 with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
     data = f.read()
 
-# Anchor: isMac branch (hiddenInset) -> the inline win32 predicate -> the
-# hidden-title-bar Object.assign. Every minified id (config var, platform flag
-# symbol) churns; we anchor purely on the developer string literals and capture
-# the one minified token we must preserve verbatim: the config var in the
-# Object.assign that the win32 branch mutates.
+# Anchor: the inline win32 predicate -> the hidden-title-bar Object.assign.
+# Every minified id (config var, platform flag symbol) churns; we anchor purely
+# on the developer string literals and capture the one minified token we must
+# preserve verbatim: the config var in the Object.assign that the win32 branch
+# mutates.
 #
-# We widen ONLY the `"win32"===process.platform` that sits between the
-# `hiddenInset` mac branch and the hidden-title-bar Object.assign. The marker
-# comment is injected inside the widened predicate so the idempotency grep and
-# the per-site count both key on the same insertion.
+# We widen ONLY the `"win32"===process.platform` that sits immediately before
+# the hidden-title-bar Object.assign. The marker comment is injected inside the
+# widened predicate so the idempotency grep and the per-site count both key on
+# the same insertion.
 site = re.compile(
-    r'(titleBarStyle:"hiddenInset"\}\):)'                 # g1: mac branch end + ':'
-    r'("win32"===process\.platform)'                      # g2: win32 predicate
-    r'(&&Object\.assign\((?P<var>[\w$]+),'                # g3: &&assign( + var
+    r'("win32"===process\.platform)'                      # g1: win32 predicate
+    r'(&&Object\.assign\((?P<var>[\w$]+),'                # g2: &&assign( + var
     r'\{titleBarStyle:"hidden",autoHideMenuBar:!0\}\))'   # ...hidden cfg )
 )
 matches = list(site.finditer(data))
 
-# How many window configs of this shape SHOULD exist. The audit found exactly
-# one (the Settings/Hub window). If the bundle ever sprouts another of this
-# exact shape, EXPECTED must be bumped deliberately after re-auditing -- we do
-# not silently widen an unknown count.
+# How many window configs of this shape SHOULD exist. The 1.5.695 audit found
+# exactly one (the meeting_recorder window). If the bundle ever sprouts another
+# of this exact shape, EXPECTED must be bumped deliberately after re-auditing --
+# we do not silently widen an unknown count.
 EXPECTED = 1
 if len(matches) != EXPECTED:
     sys.exit(
@@ -135,10 +150,9 @@ if len(matches) != EXPECTED:
 # adjacency, and the marker grep short-circuits before we get here anyway).
 def widen(m):
     return (
-        m.group(1)
-        + '(/*' + marker + '*/' + m.group(2)
+        '(/*' + marker + '*/' + m.group(1)
         + '||"linux"===process.platform)'
-        + m.group(3)
+        + m.group(2)
     )
 
 site_done = bool(matches)
@@ -148,7 +162,7 @@ data = site.sub(widen, data, count=EXPECTED)
 # belt-and-braces check, but it keeps the WARNING: contract if EXPECTED grows.
 if not site_done:
     print(
-        "  WARNING: " + marker + " partial -- settingsHub=" + str(site_done)
+        "  WARNING: " + marker + " partial -- meetingRecorder=" + str(site_done)
         + "; Linux chrome windows will render with a native title bar + menu "
         + "bar (the .win32 chrome controls will be misplaced)."
     )
@@ -191,7 +205,7 @@ fi
 echo "OK: Linux frameless window-config branch widened in $BUNDLE"
 echo
 echo "Patched window config now does (conceptually):"
-echo "  isMac ? {titleBarStyle:'hiddenInset'}"
+echo "  isMac ? {frame:false,titleBarStyle:'hidden',...}"
 echo "        : (isWin32 || isLinux) && {titleBarStyle:'hidden',autoHideMenuBar:true};"
 echo
 echo "Linux now gets the same hidden-title-bar chrome as Windows; the renderer"

--- a/tests/linux-patches.bats
+++ b/tests/linux-patches.bats
@@ -93,21 +93,26 @@ JS
 # =============================================================================
 
 @test "window-frame: widens the win32 hidden-titlebar predicate to include linux" {
+	# The 1.5.695 mac branch dropped "hiddenInset" -- it now sets
+	# {frame:!1,titleBarStyle:"hidden",trafficLightPosition,...}. The anchor no
+	# longer keys on the mac branch, only on the win32 predicate + hidden assign.
 	cat > "$FIX" <<'JS'
-var isMac=false,t={};
-var r=isMac?Object.assign(t,{titleBarStyle:"hiddenInset"}):"win32"===process.platform&&Object.assign(t,{titleBarStyle:"hidden",autoHideMenuBar:!0});
+var s={tD:false},t={};
+s.tD?Object.assign(t,{frame:!1,titleBarStyle:"hidden",trafficLightPosition:{x:1e4,y:10},transparent:!0,hasShadow:!0}):"win32"===process.platform&&Object.assign(t,{titleBarStyle:"hidden",autoHideMenuBar:!0});
 JS
 	run bash "$PATCH_DIR/linux-window-frame.sh" "$FIX"
 	[[ "$status" -eq 0 ]]
 	grep -q 'WISPR_LINUX_FRAMELESS' "$FIX"
 	grep -qF '"win32"===process.platform||"linux"===process.platform' "$FIX"
+	# the mac branch is left untouched
+	grep -qF 'trafficLightPosition:{x:1e4,y:10}' "$FIX"
 	node_check "$FIX"
 }
 
 @test "window-frame: idempotent on second run" {
 	cat > "$FIX" <<'JS'
-var isMac=false,t={};
-var r=isMac?Object.assign(t,{titleBarStyle:"hiddenInset"}):"win32"===process.platform&&Object.assign(t,{titleBarStyle:"hidden",autoHideMenuBar:!0});
+var s={tD:false},t={};
+s.tD?Object.assign(t,{frame:!1,titleBarStyle:"hidden",trafficLightPosition:{x:1e4,y:10},transparent:!0,hasShadow:!0}):"win32"===process.platform&&Object.assign(t,{titleBarStyle:"hidden",autoHideMenuBar:!0});
 JS
 	bash "$PATCH_DIR/linux-window-frame.sh" "$FIX"
 	assert_idempotent "$PATCH_DIR/linux-window-frame.sh" "$FIX"


### PR DESCRIPTION
## Why

The tag build `v1.0.0+wispr1.5.695` (ci.yml, **Build AMD64/ARM64**) fails in the
staging step. Root cause is one patch: `scripts/patches/linux-window-frame.sh`
finds **0** of its expected window-config sites in the Wispr Flow 1.5.695 bundle,
so `verify-patches.sh` hard-fails the build:

```
ERROR: expected exactly 1 frameless window-config site(s), found 0.
MISSING window-frame: linux frameless window branch
```

Everything else (native-sqlite modules, helper-resolver, the other markers) was
already green — this is purely a re-audit against a new Wispr version.

## What moved in 1.5.695

The window-config *shape* changed:

- The mac branch dropped `titleBarStyle:"hiddenInset"` — it now sets
  `{frame:!1,titleBarStyle:"hidden",trafficLightPosition,...}`. The old anchor
  keyed on the `hiddenInset` mac branch, so it matched nothing.
- The lone surviving three-way `"win32"===process.platform && Object.assign(…)`
  site shifted from the **Flow Hub** window to the **meeting_recorder** window.
  The Hub and scratchpad windows now use a two-way
  `isMac ? {…} : {frame:!1,autoHideMenuBar:!0}` switch whose else branch already
  frames Linux; overlay / status / contextMenu / calendar_reminder set
  `frame:!1` unconditionally. meeting_recorder is the only window still leaving
  Linux on the native-frame default.

## Fix

Re-anchor on the still-unique `"win32"===process.platform` +
`Object.assign(<var>,{titleBarStyle:"hidden",autoHideMenuBar:!0})` literal pair
(dropping the churning mac branch from the anchor). The `EXPECTED` count
assertion, the `WISPR_LINUX_FRAMELESS` marker, and byte-identical idempotency are
all preserved.

## Verification

- Pulled the live 1.5.695 installer, extracted `app.asar`, tested the new regex
  against the **shipped minified bytes**: 1 match, var `t`.
- Patch applies, `node --check` OK, second run is a byte-identical no-op.
- `./build.sh --build deb --clean no --exe …` stages clean; `verify-patches.sh`
  reports **all 9 markers present**; `.deb` produced.
- `bats tests/linux-patches.bats` → 12/12 green (fixture updated to the new shape).
- `shellcheck` + `codespell` clean.
- Refreshed the `patching-minified-js` and `platform-gates` learnings.

## Secondary commit — Node 24 action bumps

GitHub forces the Node 20 action runtime to Node 24 on 2026-06-16. Bumped each
SHA-pinned action to the first major that defaults to Node 24:

| Action | Was | Now |
|---|---|---|
| actions/checkout | v4 | v6.0.3 (matches tests.yml's existing pin) |
| actions/upload-artifact | v4 | v6.0.0 |
| actions/download-artifact | v4 | v7.0.0 |
| softprops/action-gh-release | v2 | v3.0.0 |

All four are pure Node 20→24 runtime moves for this repo's usage (downloads are
by `name`/`merge-multiple`, not `artifact-ids`; uploads are standard archives;
gh-release v3 only moves the runtime). Stayed below the artifact actions' ESM /
digest-error majors (upload v7 / download v8) to avoid unrelated behavior
changes. `actionlint` clean.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>
85% AI / 15% Human
Claude: re-audited the 1.5.695 bundle, located the moved window-config site, rewrote the patch anchor + bats fixture, refreshed the learnings, resolved and pinned the Node 24 action SHAs, and ran the full local stage build + test gates.
Human: reported the failing release build and the isolated root cause, set the constraints (keep marker/count/idempotency), and authorized the action bumps.