### PR TITLE
fix(ci): make the rpm and appimage release legs produce artifacts

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -31,6 +31,9 @@ jobs:
     container: ${{ inputs.artifact_suffix == 'rpm' && 'fedora:42' || '' }}
     env:
       GH_TOKEN: ${{ github.token }}
+      # appimagetool is itself an AppImage; extract-and-run it instead of relying
+      # on FUSE, which is unreliable on hosted runners. No-op for the deb/rpm legs.
+      APPIMAGE_EXTRACT_AND_RUN: "1"
 
     steps:
       - name: Checkout repository
@@ -40,13 +43,20 @@ jobs:
         if: inputs.artifact_suffix == 'rpm'
         run: |
           # nodejs/npm: @electron/asar extract+repack and native-module fetch.
+          # build.sh's dependency installer (scripts/setup/dependencies.sh) pulls
+          # the rest (p7zip, python3, rpm-build, ...) once it runs.
           dnf install -y git findutils which curl nodejs npm
 
-      - name: Install FUSE for AppImageTool (Ubuntu)
-        if: inputs.artifact_suffix != 'rpm'
+      - name: Install AppImage tooling (Ubuntu)
+        if: inputs.artifact_suffix == 'appimage'
         run: |
           sudo apt-get update
           sudo apt-get install -y libfuse2
+          # appimagetool is not a distro package; fetch the arch-matched build so
+          # the appimage maker (scripts/packaging/appimage.sh) finds it on PATH.
+          curl -fSL -o /tmp/appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+          sudo install -m 0755 /tmp/appimagetool /usr/local/bin/appimagetool
 
       - name: Make scripts executable
         run: chmod +x ./build.sh scripts/setup/resolve-installer-url.sh scripts/setup/fetch-helper-bin.sh

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -32,6 +32,9 @@ jobs:
     container: ${{ inputs.artifact_suffix == 'rpm' && 'fedora:42' || '' }}
     env:
       GH_TOKEN: ${{ github.token }}
+      # appimagetool is itself an AppImage; extract-and-run it instead of relying
+      # on FUSE, which is unreliable on hosted runners. No-op for the deb/rpm legs.
+      APPIMAGE_EXTRACT_AND_RUN: "1"
 
     steps:
       - name: Checkout repository
@@ -41,13 +44,20 @@ jobs:
         if: inputs.artifact_suffix == 'rpm'
         run: |
           # nodejs/npm: @electron/asar extract+repack and native-module fetch.
+          # build.sh's dependency installer (scripts/setup/dependencies.sh) pulls
+          # the rest (p7zip, python3, rpm-build, ...) once it runs.
           dnf install -y git findutils which curl nodejs npm
 
-      - name: Install FUSE for AppImageTool (Ubuntu)
-        if: inputs.artifact_suffix != 'rpm'
+      - name: Install AppImage tooling (Ubuntu)
+        if: inputs.artifact_suffix == 'appimage'
         run: |
           sudo apt-get update
           sudo apt-get install -y libfuse2
+          # appimagetool is not a distro package; fetch the arch-matched build so
+          # the appimage maker (scripts/packaging/appimage.sh) finds it on PATH.
+          curl -fSL -o /tmp/appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-aarch64.AppImage"
+          sudo install -m 0755 /tmp/appimagetool /usr/local/bin/appimagetool
 
       - name: Make scripts executable
         run: chmod +x ./build.sh scripts/setup/resolve-installer-url.sh scripts/setup/fetch-helper-bin.sh

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -15,16 +15,24 @@
 #   rsync                     -- stage resource trees
 #   node, npx                 -- @electron/asar pack/unpack + helpers
 #   cargo                     -- build the clean-room Rust helper (release)
+#   python3                   -- run the bundle patch suite (scripts/patches/*)
 # Format-specific:
 #   rpmbuild   (rpm-build)    -- only for --build rpm
 #   dpkg-deb   (dpkg-dev/dpkg)-- only for --build deb
+#
+# python3 is REQUIRED: every patch under scripts/patches/ (helper-resolver,
+# mac-gates, linux-window-frame, ...) drives its `re`-based rewrite through
+# python3, and build-linux.sh Step 3 runs them unconditionally. Debian/Ubuntu
+# ship python3 in the base image so it is silently present there, but minimal
+# images (e.g. the fedora:42 rpm container) do not -- without it every patch
+# fails `python3: command not found` and verify-patches.sh then fails the build.
 #
 # NOTE: the native sqlite addons are fetched as pinned, provenance-verified
 # prebuilt assets (scripts/setup/fetch-native-bin.sh), so no C/C++ toolchain is
 # required for the normal build. Only the OPTIONAL local from-source rebuild
 # fallback (build-linux.sh Step 4 -> rebuild-native-modules.sh) needs a compiler
-# + make + python3; it reports any missing tool itself, so they are not forced
-# system deps here.
+# + make; it reports any missing tool itself, so those are not forced system
+# deps here.
 #===============================================================================
 
 check_dependencies() {
@@ -32,7 +40,7 @@ check_dependencies() {
 
 	# Logical commands the build needs. wget/curl is satisfied by EITHER, so we
 	# check that pair specially below rather than listing both here.
-	local common_deps='7z wrestool icotool convert rsync node npx cargo'
+	local common_deps='7z wrestool icotool convert rsync node npx cargo python3'
 	local all_deps="$common_deps"
 
 	case "$build_format" in
@@ -45,13 +53,13 @@ check_dependencies() {
 		[7z]='p7zip-full' [wrestool]='icoutils' [icotool]='icoutils'
 		[convert]='imagemagick' [rsync]='rsync' [node]='nodejs' [npx]='npm'
 		[cargo]='cargo' [dpkg-deb]='dpkg-dev' [rpmbuild]='rpm'
-		[wget]='wget' [curl]='curl'
+		[python3]='python3' [wget]='wget' [curl]='curl'
 	)
 	declare -A rpm_pkgs=(
 		[7z]='p7zip p7zip-plugins' [wrestool]='icoutils' [icotool]='icoutils'
 		[convert]='ImageMagick' [rsync]='rsync' [node]='nodejs' [npx]='npm'
 		[cargo]='cargo' [dpkg-deb]='dpkg' [rpmbuild]='rpm-build'
-		[wget]='wget' [curl]='curl'
+		[python3]='python3' [wget]='wget' [curl]='curl'
 	)
 
 	local deps_to_install=''


### PR DESCRIPTION
## Why

Fixing the window-frame patch (#5) turned the **deb** legs of the
`v1.0.0+wispr1.5.695` release green, which exposed two **pre-existing** failures
the earlier window-frame error had masked (every build leg died at the
window-frame count assertion first):

| Leg | Result before | Root cause |
|---|---|---|
| deb (amd64/arm64) | ✅ pass | — |
| rpm (amd64/arm64) | ❌ fail | `python3: command not found` in the `fedora:42` container → all patches no-op → unpatched asar → verify-patches fails |
| appimage (amd64/arm64) | ❌ fail | `appimagetool` not installed → AppDir staged but no `.AppImage` → empty `out/` → upload-artifact errors |

Both are environment gaps, not code bugs — the patches (including the #5
window-frame fix) applied cleanly and `verify-patches.sh` passed in the deb and
appimage legs.

## Fix

**rpm — `scripts/setup/dependencies.sh`:** the build's dependency auto-installer
mapped logical deps to distro packages but omitted `python3`, which the *entire*
patch suite drives its `re`-based rewrites through (build-linux.sh Step 3 runs
them unconditionally). Debian/Ubuntu ship python3 in the base image so it was
silently present; the minimal `fedora:42` image does not. Added `python3` to
`common_deps` and both distro package maps. (`rpm-build` was already covered.)

**appimage — `build-amd64.yml` / `build-arm64.yml`:** appimagetool is a
GitHub-released AppImage, not a distro package, so it can't live in
dependencies.sh — the maker is designed to skip gracefully without it. The
appimage leg now downloads the arch-matched `appimagetool` onto PATH, and the
job sets `APPIMAGE_EXTRACT_AND_RUN=1` so it runs without FUSE on hosted runners.
Narrowed the formerly deb+appimage tooling step to the appimage leg only (deb
needs neither FUSE nor appimagetool).

## Verification

Validated locally on a fedora-family host against the live 1.5.695 installer:

```
./build.sh --build deb      --clean no --exe … → wispr-flow_1.5.695_amd64.deb
./build.sh --build rpm      --clean no --exe … → wispr-flow-1.5.695-1.x86_64.rpm
./build.sh --build appimage --clean no --exe … → wispr-flow-1.5.695-x86_64.AppImage
```

All three produce artifacts with **every verify-patches marker present**.
`shellcheck` + `actionlint` clean. Both appimagetool continuous URLs return 200.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>
80% AI / 20% Human
Claude: diagnosed both leg failures from the CI logs, traced the python3 gap to dependencies.sh and the appimagetool gap to the workflow, wrote both fixes, and validated all three package formats locally.
Human: flagged the mixed release results and steered toward getting the full pipeline green.