### PR TITLE
docs: add end-user install instructions for the published packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,11 @@ Wayland — this is the baseline).
 - **Project governance / meta**: this `CHANGELOG.md`, `CONTRIBUTING.md`,
   `SECURITY.md`, the synced `AGENTS.md` / `CLAUDE.md` agent guide, GitHub issue
   templates (`.github/ISSUE_TEMPLATE/`), and `.github/CODEOWNERS`.
+- **End-user install documentation** ([`docs/installation.md`](docs/installation.md)
+  + an Installation section in the README): the APT and DNF repositories, the
+  `wispr-flow-appimage` AUR package, AppImage / manual download, plus updating and
+  uninstalling — covering the now-published `.deb` / `.rpm` / AppImage packages
+  for amd64 and arm64.
 
 ### Changed
 
@@ -81,6 +86,10 @@ Wayland — this is the baseline).
   trees (`build-linux/`, `extract/`), vendored `tools/`, lockfiles, the
   proprietary `.exe`, `linux-helper-app/target/`, and the minified `index.js`;
   ignore-words list extended with project false-positives.
+- **Pinned GitHub Actions bumped to Node 24 runtimes** ahead of GitHub's Node 20
+  deprecation: `actions/checkout` → v6.0.3, `actions/upload-artifact` → v6.0.0,
+  `actions/download-artifact` → v7.0.0, `softprops/action-gh-release` → v3.0.0
+  (each still pinned by commit SHA).
 
 ### Fixed
 
@@ -132,6 +141,20 @@ Wayland — this is the baseline).
   The guard now includes Linux (the warm-start `second-instance` path already
   worked). Marker `WISPR_LINUX_DEEPLINK`. All four patches are documented in
   [`docs/learnings/platform-gates.md`](docs/learnings/platform-gates.md).
+- **Release build failed staging on Wispr Flow 1.5.695** (`linux-window-frame.sh`):
+  the upstream window-config refactor dropped `titleBarStyle:"hiddenInset"` and
+  moved the lone three-way win32 site from the Hub window to the meeting_recorder
+  window, so the old anchor matched 0 sites and `verify-patches.sh` failed. Re-
+  anchored on the still-unique `"win32"===process.platform` +
+  `Object.assign(<var>,{titleBarStyle:"hidden",autoHideMenuBar:!0})` pair; marker,
+  count assertion, and idempotency preserved.
+- **`.rpm` and AppImage release legs produced no artifacts** once the staging
+  failure above was fixed: the `fedora:42` rpm container lacked `python3` (which
+  the entire patch suite requires) because `scripts/setup/dependencies.sh` never
+  listed it, and the appimage leg lacked `appimagetool`. Added `python3` as a
+  first-class build dependency and made the appimage CI leg fetch the arch-matched
+  `appimagetool` (with `APPIMAGE_EXTRACT_AND_RUN`). All three formats now build
+  and publish for amd64 and arm64.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,57 @@ Security: [`SECURITY.md`](SECURITY.md).
 
 ## Status
 
-We're at Phase 0, and here's what that means in practice. The app **launches** on
-Linux with the Linux helper wired in, the UI renders, and text injection is
-validated on KDE Plasma Wayland. Packaging is partway there: **`.rpm` builds
-today**; `.deb` and AppImage are stubbed (in progress); Nix is deferred. I list
-the validated environments in
+The app **launches** on Linux with the Linux helper wired in, the UI renders, and
+text injection is validated on KDE Plasma Wayland. Packaging now ships **`.deb`,
+`.rpm`, and AppImage** for **amd64 and arm64** — signed APT/DNF repos, an AUR
+package, and GitHub Release assets all publish on each tag (see
+[Installation](#installation)). Nix is wired (`flake.nix`) but not yet a release
+target. I list the validated environments in
 [`docs/compatibility.md`](docs/compatibility.md), and the design rationale lives
 in [`docs/decisions.md`](docs/decisions.md).
+
+> [!NOTE]
+> arm64 is built and published but not hardware-validated yet — the helper's
+> VM-matrix sweep ran on x86_64 only.
+
+## Installation
+
+Prebuilt packages ship for **amd64 and arm64** with every release. Pick the
+channel for your distro; the repo channels update with your normal system
+upgrades. Full details — signature verification, uninstall, per-format notes —
+are in [`docs/installation.md`](docs/installation.md).
+
+### APT (Debian/Ubuntu)
+
+```bash
+curl -fsSL https://pkg.wispr-flow-linux.dev/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/wispr-flow.gpg
+echo "deb [signed-by=/usr/share/keyrings/wispr-flow.gpg arch=amd64,arm64] https://pkg.wispr-flow-linux.dev stable main" | sudo tee /etc/apt/sources.list.d/wispr-flow.list
+sudo apt update && sudo apt install wispr-flow
+```
+
+### DNF (Fedora/RHEL)
+
+```bash
+sudo curl -fsSL https://pkg.wispr-flow-linux.dev/rpm/wispr-flow.repo -o /etc/yum.repos.d/wispr-flow.repo
+sudo dnf install wispr-flow
+```
+
+### AUR (Arch Linux)
+
+```bash
+yay -S wispr-flow-appimage   # or: paru -S wispr-flow-appimage
+```
+
+### Manual download
+
+Grab a `.deb`, `.rpm`, or `.AppImage` from the
+[Releases page](https://github.com/wispr-flow-linux/wispr-flow-linux/releases).
+
+> [!NOTE]
+> These published packages bundle the proprietary Wispr Flow app, downloaded from
+> Wispr's official endpoint at build time. Wispr Flow is a trademark of its
+> owners; this is an unofficial community port. Prefer to supply the installer
+> yourself? [Build from source](#building) instead.
 
 ## Supported environments
 
@@ -53,7 +97,7 @@ Build a package with:
 
 ```bash
 # Build an .rpm from a Wispr Flow installer you obtained yourself
-./build.sh --build rpm --exe ~/Downloads/"Wispr Flow Setup-v1.5.619.exe"
+./build.sh --build rpm --exe ~/Downloads/"Wispr Flow Setup-v1.5.695.exe"
 ```
 
 `--exe` is required. The pipeline never fetches, bundles, or hosts the

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,8 @@ protocol — the contract everything else hangs off — is in
 
 ## Installation & building
 
+- [**Installing**](installation.md) — prebuilt packages: the APT/DNF repos, the
+  AUR package, AppImage / manual download, updating, and uninstalling
 - [**Building from source**](building.md) — `./build.sh`, format flags, the
   Electron download, the native sqlite rebuild, the mandatory launcher rename
 - [**Configuration**](configuration.md) — env vars, where state lives, the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,159 @@
+[< Back to docs index](index.md)
+
+# Installing Wispr Flow for Linux
+
+Install a prebuilt, signed package for your distro — `.deb`, `.rpm`, and AppImage
+ship for **amd64 and arm64** on every release.
+
+```bash
+# Debian/Ubuntu, the short version:
+curl -fsSL https://pkg.wispr-flow-linux.dev/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/wispr-flow.gpg
+echo "deb [signed-by=/usr/share/keyrings/wispr-flow.gpg arch=amd64,arm64] https://pkg.wispr-flow-linux.dev stable main" | sudo tee /etc/apt/sources.list.d/wispr-flow.list
+sudo apt update && sudo apt install wispr-flow
+```
+
+> [!NOTE]
+> These packages bundle the proprietary Wispr Flow app, downloaded from Wispr's
+> official endpoint at build time. Wispr Flow is a trademark of its owners; this
+> is an unofficial community port. To supply the installer yourself instead, see
+> [building.md](building.md).
+
+## Choose a channel
+
+| Distro family | Channel | Auto-updates |
+|---|---|---|
+| Debian / Ubuntu | [APT repository](#apt-debianubuntu) | yes — `apt upgrade` |
+| Fedora / RHEL | [DNF repository](#dnf-fedorarhel) | yes — `dnf upgrade` |
+| Arch | [AUR `wispr-flow-appimage`](#aur-arch-linux) | yes — AUR helper |
+| Any | [Manual `.deb` / `.rpm` / `.AppImage`](#manual-download) | no — re-download |
+
+The repository channels are the recommended path: they pin the signing key and
+pull new versions with your normal system updates. Architecture is auto-selected
+(amd64 or arm64).
+
+## APT (Debian/Ubuntu)
+
+```bash
+# 1. Pin the repository signing key
+curl -fsSL https://pkg.wispr-flow-linux.dev/KEY.gpg \
+  | sudo gpg --dearmor -o /usr/share/keyrings/wispr-flow.gpg
+
+# 2. Add the repository
+echo "deb [signed-by=/usr/share/keyrings/wispr-flow.gpg arch=amd64,arm64] https://pkg.wispr-flow-linux.dev stable main" \
+  | sudo tee /etc/apt/sources.list.d/wispr-flow.list
+
+# 3. Install
+sudo apt update && sudo apt install wispr-flow
+```
+
+Updates arrive with your regular `sudo apt upgrade`.
+
+## DNF (Fedora/RHEL)
+
+```bash
+# 1. Add the repository (the .repo file pins the signing key)
+sudo curl -fsSL https://pkg.wispr-flow-linux.dev/rpm/wispr-flow.repo \
+  -o /etc/yum.repos.d/wispr-flow.repo
+
+# 2. Install
+sudo dnf install wispr-flow
+```
+
+Both `gpgcheck` and `repo_gpgcheck` are on, so DNF verifies the package and the
+repository metadata against the key at
+`https://pkg.wispr-flow-linux.dev/KEY.gpg`. Updates arrive with
+`sudo dnf upgrade`.
+
+## AUR (Arch Linux)
+
+The [`wispr-flow-appimage`](https://aur.archlinux.org/packages/wispr-flow-appimage)
+package wraps the AppImage build and tracks each release.
+
+```bash
+yay -S wispr-flow-appimage
+# or
+paru -S wispr-flow-appimage
+```
+
+## Manual download
+
+Grab a `.deb`, `.rpm`, or `.AppImage` for your architecture from the
+[Releases page](https://github.com/wispr-flow-linux/wispr-flow-linux/releases),
+then:
+
+```bash
+# Debian/Ubuntu
+sudo apt install ./wispr-flow_*_amd64.deb
+
+# Fedora/RHEL
+sudo dnf install ./wispr-flow-*.x86_64.rpm
+
+# AppImage — mark executable and run
+chmod +x ./wispr-flow-*-x86_64.AppImage
+./wispr-flow-*-x86_64.AppImage
+```
+
+The `.deb` / `.rpm` postinst installs the `/dev/uinput` udev rule for you. The
+AppImage cannot run a root postinst, so install the rule once:
+
+```bash
+./wispr-flow-*-x86_64.AppImage --install-udev-rules
+```
+
+## After installing
+
+Run the built-in diagnostic first — it checks the display server / session,
+`/dev/uinput` access, clipboard tooling, the GNOME extension, AT-SPI,
+push-to-talk input access, and the launcher rename:
+
+```bash
+wispr-flow --doctor
+```
+
+Text injection needs write access to `/dev/uinput` (granted by the bundled udev
+rule via the logind `uaccess` ACL, with the `input` group as a fallback);
+push-to-talk additionally needs read access to `/dev/input/event*`. Group changes
+take effect on your next login. The full list of env vars, state locations, the
+udev rule, clipboard dependencies, the GNOME Shell extension, and AT-SPI is in
+[configuration.md](configuration.md); symptom-keyed fixes are in
+[troubleshooting.md](troubleshooting.md).
+
+## Updating
+
+- **APT / DNF:** new releases install with your normal `sudo apt upgrade` /
+  `sudo dnf upgrade`.
+- **AUR:** re-run your AUR helper (`yay -Syu`).
+- **Manual:** download the new asset and reinstall it.
+
+## Uninstalling
+
+```bash
+sudo apt remove wispr-flow      # Debian/Ubuntu
+sudo dnf remove wispr-flow      # Fedora/RHEL
+yay -R wispr-flow-appimage      # Arch
+
+# Also remove the repository channel if you added one:
+sudo rm /etc/apt/sources.list.d/wispr-flow.list /usr/share/keyrings/wispr-flow.gpg   # APT
+sudo rm /etc/yum.repos.d/wispr-flow.repo                                             # DNF
+```
+
+User state (config, logs) lives under the paths documented in
+[configuration.md](configuration.md); remove those separately if you want a clean
+slate.
+
+## How distribution works
+
+`pkg.wispr-flow-linux.dev` is a Cloudflare Worker that serves the APT/DNF metadata
+and 302-redirects package downloads to the matching GitHub Release asset, so the
+package bytes never hit GitHub's 100 MB push cap. The mechanics are in
+[learnings/apt-worker-architecture.md](learnings/apt-worker-architecture.md); the
+tag-driven publish flow is in [RELEASING.md](../RELEASING.md).
+
+## See also
+
+- [building.md](building.md) — build a package yourself from an installer you
+  supply (no proprietary bytes bundled)
+- [compatibility.md](compatibility.md) — validated compositors and per-backend
+  access requirements
+- [troubleshooting.md](troubleshooting.md) — `--doctor` output and symptom-keyed
+  fixes


### PR DESCRIPTION
## Why

The first full release (`v1.0.0+wispr1.5.695`) now publishes signed
`.deb`/`.rpm`/AppImage packages for **amd64 and arm64** via APT/DNF repos, the
AUR, and GitHub Releases — but the docs still described Phase-0 stubs (".rpm
builds today; .deb/AppImage stubbed") and had no install path for users. This
adds install instructions in the style of `claude-desktop-debian`.

## Changes

- **README**: replaced the stale **Status** section with the real packaging state
  and added an **Installation** section (APT / DNF / AUR / manual), including the
  proprietary-bundle disclaimer and an arm64-not-hardware-validated note.
- **`docs/installation.md`** (new): full how-to — a channel chooser table,
  per-distro repository setup, AppImage `--install-udev-rules`, `--doctor`,
  updating, uninstalling, and a short note on how the `pkg.wispr-flow-linux.dev`
  redirect Worker serves the packages.
- **`docs/index.md`**: linked the new page under "Installation & building".
- **CHANGELOG**: noted the install docs, the Node 24 action bumps, and the
  window-frame re-audit + rpm/appimage release-leg fixes from this work.

## Verification

Every documented command was checked against the **live** endpoints — `KEY.gpg`,
`rpm/wispr-flow.repo`, `dists/stable/Release`, `conf/distributions`, and the AUR
`wispr-flow-appimage` page all return `200`. The install snippets are copied
verbatim from the ones CI emits in the release notes. `codespell` clean; all
internal doc links resolve.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>
90% AI / 10% Human
Claude: wrote the README install section and docs/installation.md, refreshed the stale status, updated the index + CHANGELOG, and verified every endpoint and link.
Human: requested install instructions modeled on the claude-desktop-debian repo.