### PR TITLE
fix(packaging,doctor): align with claude-desktop-debian hardening

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -51,7 +51,9 @@ jobs:
         if: inputs.artifact_suffix == 'appimage'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfuse2
+          # zsync lets the appimage maker emit a .zsync delta for AppImage
+          # auto-updates (AppImageUpdate / appimaged).
+          sudo apt-get install -y libfuse2 zsync
           # appimagetool is not a distro package; fetch the arch-matched build so
           # the appimage maker (scripts/packaging/appimage.sh) finds it on PATH.
           curl -fSL -o /tmp/appimagetool \
@@ -92,7 +94,8 @@ jobs:
           find build-linux \
             \( -name 'wispr-flow_*.deb' \
             -o -name 'wispr-flow-*.rpm' \
-            -o -name 'wispr-flow-*.AppImage' \) \
+            -o -name 'wispr-flow-*.AppImage' \
+            -o -name 'wispr-flow-*.AppImage.zsync' \) \
             -exec cp -v {} out/ \;
 
       # Static-grep the shipped app.asar for the Linux patch markers. Pinned to

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -52,7 +52,9 @@ jobs:
         if: inputs.artifact_suffix == 'appimage'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libfuse2
+          # zsync lets the appimage maker emit a .zsync delta for AppImage
+          # auto-updates (AppImageUpdate / appimaged).
+          sudo apt-get install -y libfuse2 zsync
           # appimagetool is not a distro package; fetch the arch-matched build so
           # the appimage maker (scripts/packaging/appimage.sh) finds it on PATH.
           curl -fSL -o /tmp/appimagetool \
@@ -90,7 +92,8 @@ jobs:
           find build-linux \
             \( -name 'wispr-flow_*.deb' \
             -o -name 'wispr-flow-*.rpm' \
-            -o -name 'wispr-flow-*.AppImage' \) \
+            -o -name 'wispr-flow-*.AppImage' \
+            -o -name 'wispr-flow-*.AppImage.zsync' \) \
             -exec cp -v {} out/ \;
 
       - name: Upload ARM64 Artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,21 @@ Wayland — this is the baseline).
   `wispr-flow-appimage` AUR package, AppImage / manual download, plus updating and
   uninstalling — covering the now-published `.deb` / `.rpm` / AppImage packages
   for amd64 and arm64.
+- **AppImage auto-update metadata** (`scripts/packaging/appimage.sh` + the
+  `build-amd64` / `build-arm64` CI legs): CI builds now embed
+  `gh-releases-zsync` update information and emit a companion `.AppImage.zsync`
+  delta (the legs install `zsync` and collect the `.zsync` alongside the
+  `.AppImage`), so published AppImages self-update via AppImageUpdate /
+  appimaged. Local builds skip it (no release to update from).
+- **`wispr-flow --doctor` install-integrity checks** (`scripts/doctor.sh`):
+  a **chrome-sandbox** check (setuid-root `4755` / owner `root`, AppImage-aware
+  via `$APPIMAGE` since those run `--no-sandbox`), an **Electron runtime** check
+  (the renamed binary exists / is executable, version read from the sibling
+  `version` file without launching Electron), a **desktop entry** presence
+  check, and a **free-disk** check on the config partition. The three launchers
+  now thread the Electron binary path into `run_doctor` alongside the helper
+  path. Catches a sandbox that lost its setuid bit (Electron silently refuses to
+  start) and other partial installs that previously reported "all checks passed."
 
 ### Changed
 
@@ -90,6 +105,19 @@ Wayland — this is the baseline).
   deprecation: `actions/checkout` → v6.0.3, `actions/upload-artifact` → v6.0.0,
   `actions/download-artifact` → v7.0.0, `softprops/action-gh-release` → v3.0.0
   (each still pinned by commit SHA).
+- **README opening** rewritten in `claude-desktop-debian`'s declarative
+  "build scripts to run … natively on Linux" style (enumerating the `.deb` /
+  `.rpm` / AppImage / AUR / Nix outputs up front), and the **Status** and
+  **Supported environments** sections removed — the validated-environments
+  matrix and the `/dev/uinput` access notes already live in
+  [`docs/configuration.md`](docs/configuration.md).
+- **`verify-patches.sh`** dropped `set -e` (`set -euo pipefail` → `set -uo
+  pipefail`) to comply with the bash styleguide; the marker probes already
+  tolerate a no-match via `|| true` and accumulate into `missing`.
+- **rpm spec hardening made explicit** (`scripts/packaging/rpm.sh`): added a
+  `%defattr(-, root, root, -)` default and an explicit `%global debug_package
+  %{nil}`, belt-and-suspenders over the existing `__os_install_post %{nil}`
+  across rpm versions.
 
 ### Fixed
 
@@ -155,6 +183,23 @@ Wayland — this is the baseline).
   first-class build dependency and made the appimage CI leg fetch the arch-matched
   `appimagetool` (with `APPIMAGE_EXTRACT_AND_RUN`). All three formats now build
   and publish for amd64 and arm64.
+- **rpm could silently ship a non-setuid / missing chrome-sandbox**
+  (`scripts/packaging/rpm.sh`): `%files` listed the sandbox twice — once via the
+  `/usr/lib/wispr-flow` dir walk and again as an `%attr(4755, …)` entry — and on
+  modern rpmbuild (6.x) the "File listed twice" path can strip the file from the
+  payload, leaving Electron unable to start sandboxed. The setuid bit is now
+  baked into the FHS tree before the spec is written (so the single dir-walk
+  listing records `4755`), the rpmbuild output is captured, and the build fails
+  hard if rpmbuild emits "File listed twice" (guards against #609 regressing).
+- **`build.sh --clean yes` was a no-op** (it only printed a warning): cleanup now
+  prunes the regenerable intermediate trees (`stage`, `app.asar.contents`, the
+  per-format packaging scaffolding / AppDir) while preserving the produced
+  package and the expensive `downloads/` tree (installer + Electron runtime).
+- **Standalone `build-linux.sh` staged a stale version**
+  (`scripts/build-linux.sh` + the makers): the `APP_VERSION` default was still
+  `1.5.619` while `build.sh` targets `1.5.695`, so a direct
+  `scripts/build-linux.sh` run (outside the orchestrator) mislabeled the staged
+  tree. Aligned every default and example to `1.5.695`.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 [![CI](https://github.com/wispr-flow-linux/wispr-flow-linux/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/wispr-flow-linux/wispr-flow-linux/actions/workflows/ci.yml?query=branch%3Amain)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](UNLICENSE)
 
-Hey! These are build scripts to run the proprietary **Wispr Flow** voice-dictation
-app natively on Linux. I wanted Wispr Flow on my Linux machine, so this repo
-repackages the Windows installer and pairs it with a **clean-room Rust helper**.
-That helper reimplements the one native capability Wispr Flow ships only for macOS
-and Windows: injecting transcribed text into your focused application.
+This project provides build scripts to run the proprietary **Wispr Flow**
+voice-dictation app natively on Linux. It repackages the Windows installer and
+pairs it with a **clean-room Rust helper**, producing `.deb` packages
+(Debian/Ubuntu), `.rpm` packages (Fedora/RHEL), and distribution-agnostic
+AppImages for amd64 and arm64, plus an
+[AUR package](https://aur.archlinux.org/packages/wispr-flow-appimage) for Arch
+Linux and a Nix flake. The helper reimplements the one native capability Wispr
+Flow ships only for macOS and Windows: injecting transcribed text into your
+focused application.
 
 **This is an unofficial port.** I'm not affiliated with Wispr. For the official
 app and support, see [wisprflow.ai](https://wisprflow.ai). If you hit a
@@ -18,21 +22,6 @@ build-script or Linux issue,
 in [`docs/building.md`](docs/building.md). Release history in
 [`CHANGELOG.md`](CHANGELOG.md). Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md).
 Security: [`SECURITY.md`](SECURITY.md).
-
-## Status
-
-The app **launches** on Linux with the Linux helper wired in, the UI renders, and
-text injection is validated on KDE Plasma Wayland. Packaging now ships **`.deb`,
-`.rpm`, and AppImage** for **amd64 and arm64** — signed APT/DNF repos, an AUR
-package, and GitHub Release assets all publish on each tag (see
-[Installation](#installation)). Nix is wired (`flake.nix`) but not yet a release
-target. I list the validated environments in
-[`docs/compatibility.md`](docs/compatibility.md), and the design rationale lives
-in [`docs/decisions.md`](docs/decisions.md).
-
-> [!NOTE]
-> arm64 is built and published but not hardware-validated yet — the helper's
-> VM-matrix sweep ran on x86_64 only.
 
 ## Installation
 
@@ -72,23 +61,6 @@ Grab a `.deb`, `.rpm`, or `.AppImage` from the
 > Wispr's official endpoint at build time. Wispr Flow is a trademark of its
 > owners; this is an unofficial community port. Prefer to supply the installer
 > yourself? [Build from source](#building) instead.
-
-## Supported environments
-
-I developed the Rust helper ([its own repo](https://github.com/wispr-flow-linux/helper))
-and swept it across a libvirt VM matrix. That sweep ran on x86_64 only, so arm64
-is wired through but not hardware-validated yet:
-
-| Environment | Text injection | Active window / focus | Selection |
-|---|---|---|---|
-| **KDE Plasma (Wayland)** — validated | `uinput` + `wl-clipboard` | KWin script over D-Bus | AT-SPI |
-| **GNOME (Wayland)** | shared Wayland backend | `org.gnome.Shell.Introspect` | AT-SPI |
-| **wlroots / other Wayland** | `uinput` + `wl-clipboard` | generic Wayland | AT-SPI |
-| **X11** | XTEST | `_NET_*` window properties | AT-SPI |
-
-Text injection needs write access to `/dev/uinput`. The bundled udev rule grants
-that through the logind `uaccess` ACL, with the `input` group as a cross-distro
-fallback. Push-to-talk additionally needs read access to `/dev/input/event*`.
 
 ## Building
 

--- a/build.sh
+++ b/build.sh
@@ -68,8 +68,8 @@ source "$script_dir/scripts/setup/download.sh"
 # Package version derivation -- mirror the claude-desktop-debian scheme.
 #
 # The release tag has the shape  v<repoVer>+wispr<wisprVer>  (e.g.
-# v1.0.0+wispr1.5.619). When a parseable tag is supplied, the package/filename
-# version becomes  <wisprVer>-<repoVer>  (e.g. 1.5.619-1.0.0) so a downstream
+# v1.0.0+wispr1.5.695). When a parseable tag is supplied, the package/filename
+# version becomes  <wisprVer>-<repoVer>  (e.g. 1.5.695-1.0.0) so a downstream
 # worker can reconstruct the release tag from a package filename. For local /
 # no-tag builds the package version stays just <wisprVer> (the APP_VERSION
 # constant), and APP_VERSION itself is NEVER altered -- staging always sees the
@@ -188,10 +188,10 @@ The Nix package is built straight from the flake, not through build.sh. It
 never fetches the proprietary app -- point it at the installer .exe you
 obtained yourself via WISPR_FLOW_EXE (needs --impure):
 
-    WISPR_FLOW_EXE="/path/Wispr Flow Setup-v1.5.619.exe" \
+    WISPR_FLOW_EXE="/path/Wispr Flow Setup-v1.5.695.exe" \
       nix build .#wispr-flow-fhs --impure   # recommended (glibc FHS wrapper)
 
-    WISPR_FLOW_EXE="/path/Wispr Flow Setup-v1.5.619.exe" \
+    WISPR_FLOW_EXE="/path/Wispr Flow Setup-v1.5.695.exe" \
       nix build .#wispr-flow --impure       # bare derivation (no FHS loader)
 
 Overlay/non-flake callers can instead override:
@@ -209,6 +209,37 @@ NIXMSG
 	else
 		warn 'Could not determine final package path.'
 	fi
+}
+
+#===============================================================================
+# Cleanup -- remove regenerable intermediate trees while preserving (a) the
+# produced package and (b) the expensive downloads/ tree (installer + Electron
+# runtime). The final artifact lives nested under the per-format dir (e.g.
+# rpm/rpmbuild/RPMS), so prune scaffolding subdirs rather than the dir itself.
+#===============================================================================
+clean_intermediates() {
+	local removed=0 target
+	for target in \
+		"$work_dir/stage" \
+		"$work_dir/app.asar.contents" \
+		"$work_dir/deb/pkgroot" \
+		"$work_dir/rpm/pkgroot" \
+		"$work_dir/rpm/rpmbuild/BUILD" \
+		"$work_dir/rpm/rpmbuild/BUILDROOT" \
+		"$work_dir/rpm/rpmbuild/SOURCES" \
+		"$work_dir/rpm/rpmbuild/SPECS" \
+		"$work_dir/rpm/rpmbuild/SRPMS"
+	do
+		[[ -e $target ]] || continue
+		rm -rf "$target" && removed=$((removed + 1))
+	done
+	# AppImage AppDir scaffolding (the .AppImage artifact sits beside it, kept).
+	local appdir
+	for appdir in "$work_dir"/appimage/*.AppDir; do
+		[[ -d $appdir ]] || continue
+		rm -rf "$appdir" && removed=$((removed + 1))
+	done
+	auto "Cleanup: removed $removed intermediate tree(s); kept the package and downloads/."
 }
 
 print_resolved_flags() {
@@ -275,8 +306,7 @@ main() {
 	# Phase 5: optional cleanup of intermediate build files.
 	if [[ $clean_action == 'yes' ]]; then
 		say 'Cleanup intermediate build files'
-		# Preserve the produced package and the downloads/electron-dist tree.
-		warn 'Cleanup requested; intermediate file cleanup is conservative (no-op for now to protect downloads/).'
+		clean_intermediates
 	fi
 
 	say 'Build process finished.'

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -47,8 +47,10 @@ WORK_DIR="$PROJECT_ROOT/build-linux"
 STAGE="$WORK_DIR/stage"                          # becomes the app's resources/ tree
 # These honor env overrides (set by the build.sh orchestrator) but default to
 # the validated values when run standalone -- behavior is identical unless an
-# override is exported.
-APP_VERSION="${APP_VERSION:-1.5.619}"
+# override is exported. Keep APP_VERSION in lockstep with build.sh's APP_VERSION
+# so a standalone `build-linux.sh` run stages the same version the orchestrator
+# does (a divergent default silently mislabels the staged tree).
+APP_VERSION="${APP_VERSION:-1.5.695}"
 ELECTRON_MAJOR="${ELECTRON_MAJOR:-42}"
 ELECTRON_VERSION="${ELECTRON_VERSION:-42.3.0}"
 ARCH="${ARCH:-x64}"   # linux-x64; the helper + sqlite must match
@@ -110,8 +112,8 @@ step1_extract() {
   manual "This was performed by Track 1; the result lives in $EXTRACT_DIR."
   manual "To redo from a fresh installer (requires 7z):"
   cat <<'DOC'
-      7z x "Wispr Flow Setup-v1.5.619.exe" -o./extract            # -> *-full.nupkg
-      7z x "./extract/WisprFlow-1.5.619-full.nupkg" -o./extract/nupkg
+      7z x "Wispr Flow Setup-v1.5.695.exe" -o./extract            # -> *-full.nupkg
+      7z x "./extract/WisprFlow-1.5.695-full.nupkg" -o./extract/nupkg
       # Electron payload is then under extract/nupkg/lib/net45/
       # (resources/app.asar, resources/app.asar.unpacked/, resources/Release/, Wispr Flow.exe, *.pak)
 DOC

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -353,13 +353,111 @@ _doctor_check_singleton_lock() {
 	fi
 }
 
+#------------------------------------------------------------------------------
+# Electron runtime — the renamed Electron binary the launcher exec's must exist
+# and be executable. Version is read from the sibling 'version' file rather than
+# launching Electron (which can hang).
+#------------------------------------------------------------------------------
+_doctor_electron_version() {
+	local version_file
+	version_file="$(dirname "$1")/version"
+	[[ -r $version_file ]] && printf '%s' "$(< "$version_file")"
+}
+
+_doctor_check_electron() {
+	local electron_path="${1:-}"
+	if [[ -z $electron_path ]]; then
+		_warn 'Electron runtime: path not provided to doctor'
+		return
+	fi
+	if [[ ! -x $electron_path ]]; then
+		_fail "Electron runtime: not found / not executable at $electron_path"
+		_info 'The launcher cannot start the app.'
+		_info 'Fix: reinstall the wispr-flow package'
+		return
+	fi
+	local ver
+	ver=$(_doctor_electron_version "$electron_path")
+	if [[ $ver =~ ^v?[0-9]+\.[0-9]+ ]]; then
+		_pass "Electron runtime: v${ver#v} ($electron_path)"
+	else
+		_pass "Electron runtime: present and executable ($electron_path)"
+	fi
+}
+
+#------------------------------------------------------------------------------
+# chrome-sandbox — must be setuid-root (4755, owner root) on deb/rpm so Electron
+# runs sandboxed. Absent on AppImage (which launches with --no-sandbox). A
+# sandbox that lost its setuid bit makes Electron refuse to start or run
+# unsandboxed, so a clean "all passed" without this check is misleading.
+#------------------------------------------------------------------------------
+_doctor_check_sandbox() {
+	local electron_path="${1:-}"
+	# AppImages launch with --no-sandbox (squashfs can't carry a setuid bit), so
+	# the bundled chrome-sandbox is intentionally not setuid there. The AppImage
+	# runtime exports APPIMAGE; treat that as "sandbox perms don't apply".
+	if [[ -n ${APPIMAGE:-} ]]; then
+		_info 'chrome-sandbox: AppImage runs with --no-sandbox (setuid not required)'
+		return
+	fi
+	local sandbox_path=''
+	[[ -n $electron_path ]] && sandbox_path="$(dirname "$electron_path")/chrome-sandbox"
+	if [[ -z $sandbox_path || ! -f $sandbox_path ]]; then
+		_warn 'chrome-sandbox: not found (expected for AppImage / --no-sandbox)'
+		return
+	fi
+	local perms owner
+	perms=$(stat -c '%a' "$sandbox_path" 2>/dev/null || echo '?')
+	owner=$(stat -c '%U' "$sandbox_path" 2>/dev/null || echo '?')
+	if [[ $perms == '4755' && $owner == 'root' ]]; then
+		_pass "chrome-sandbox: setuid-root OK ($sandbox_path)"
+	else
+		_fail "chrome-sandbox: perms=$perms owner=$owner (need 4755 root)"
+		_info 'Electron may refuse to start or run unsandboxed.'
+		_info "Fix: sudo chown root:root '$sandbox_path'"
+		_info "     sudo chmod 4755 '$sandbox_path'"
+	fi
+}
+
+#------------------------------------------------------------------------------
+# Desktop entry + free disk on the config partition — cheap install-integrity
+# checks. Out-of-disk is a known Chromium failure mode (blank window / profile
+# corruption) that is otherwise invisible.
+#------------------------------------------------------------------------------
+_doctor_check_desktop_entry() {
+	local desktop_file='/usr/share/applications/wispr-flow.desktop'
+	if [[ -f $desktop_file ]]; then
+		_pass "Desktop entry: $desktop_file"
+	else
+		_warn 'Desktop entry: not found (expected for AppImage installs)'
+	fi
+}
+
+_doctor_check_disk_space() {
+	local config_dir avail
+	config_dir="$(_doctor_config_dir)"
+	avail=$(df -BM --output=avail "$config_dir" 2>/dev/null \
+		| tail -1 | tr -d ' M') || true
+	[[ $avail =~ ^[0-9]+$ ]] || return 0
+	if ((avail < 100)); then
+		_fail "Disk space: ${avail}MB free on the config partition"
+		_info 'Chromium will fail to write its profile. Fix: free up disk space.'
+	elif ((avail < 500)); then
+		_warn "Disk space: ${avail}MB free on the config partition (low)"
+	else
+		_pass "Disk space: ${avail}MB free on the config partition"
+	fi
+}
+
 #===============================================================================
 # Entry point.
-# Arguments: $1 = path to the Linux helper binary (for the helper check and
-#            for deriving the install dir). Optional but recommended.
+# Arguments: $1 = path to the Linux helper binary (helper check).
+#            $2 = path to the Electron runtime binary (runtime / sandbox checks
+#                 derive the install dir from it). Both optional but recommended.
 #===============================================================================
 run_doctor() {
 	local helper_path="${1:-}"
+	local electron_path="${2:-}"
 	local _doctor_failures=0
 	_doctor_colors
 
@@ -408,6 +506,10 @@ run_doctor() {
 
 	echo -e "${_bold}Helper & Runtime${_reset}"
 	_doctor_check_helper "$helper_path"
+	_doctor_check_electron "$electron_path"
+	_doctor_check_sandbox "$electron_path"
+	_doctor_check_desktop_entry
+	_doctor_check_disk_space
 	_doctor_check_singleton_lock
 	_doctor_check_recent_crashes
 	echo

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -19,7 +19,7 @@
 # Shared maker signature:
 #   appimage.sh <dist_dir> <version> <arch>
 #     <dist_dir>  staged electron-dist tree (default: build-linux/downloads/electron-dist)
-#     <version>   package version (default: $APP_VERSION env or 1.5.619)
+#     <version>   package version (default: $APP_VERSION env or 1.5.695)
 #     <arch>      appimage-native arch: x86_64 | aarch64 (default: host uname -m)
 # PACKAGE_NAME / WM_CLASS / MAINTAINER / DESCRIPTION come from the environment
 # (exported by build.sh); sane defaults apply when run standalone.
@@ -32,7 +32,7 @@ SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 #--- shared maker signature ----------------------------------------------------
 DIST="${1:-$PROJECT_ROOT/build-linux/downloads/electron-dist}"
-APP_VERSION="${2:-${APP_VERSION:-1.5.619}}"
+APP_VERSION="${2:-${APP_VERSION:-1.5.695}}"
 ARCH="${3:-$(uname -m)}"
 
 #--- metadata from env, with standalone fallbacks ------------------------------
@@ -105,7 +105,7 @@ source "\$app_dir/launcher-common.sh"
 
 # Handle --doctor before anything else.
 if [[ "\${1:-}" == '--doctor' ]]; then
-	run_doctor "\$helper_bin"
+	run_doctor "\$helper_bin" "\$electron_bin"
 	exit \$?
 fi
 
@@ -235,8 +235,32 @@ fi
 say "Building AppImage with $appimagetool"
 OUT="$WORK/${NAME}-${APP_VERSION}-${ARCH}.AppImage"
 export ARCH
-if ! "$appimagetool" "$APPDIR" "$OUT"; then
-  die "appimagetool failed to build the AppImage"
+
+# In CI, embed update information and emit a .zsync delta so published AppImages
+# self-update via AppImageUpdate / appimaged. Local builds skip it (there is no
+# release to update from). Format:
+#   gh-releases-zsync|<user>|<repo>|<tag>|<filename-glob>
+# the glob matches any released version for this arch; |latest| tracks the most
+# recent GitHub Release. Keep the glob in sync with the OUT filename above.
+if [[ "${GITHUB_ACTIONS:-}" == 'true' ]]; then
+  if ! command -v zsyncmake >/dev/null 2>&1; then
+    warn 'zsyncmake not found; the .zsync delta will not be generated.'
+    warn '  Install the "zsync" package in the build environment to enable it.'
+  fi
+  update_info="gh-releases-zsync|wispr-flow-linux|wispr-flow-linux|latest|${NAME}-*-${ARCH}.AppImage.zsync"
+  say "Embedding AppImage update info: $update_info"
+  if ! "$appimagetool" --updateinformation "$update_info" "$APPDIR" "$OUT"; then
+    die "appimagetool failed to build the AppImage"
+  fi
+  if [[ -f "$OUT.zsync" ]]; then
+    echo "  zsync: $OUT.zsync (publish alongside the AppImage)"
+  else
+    warn 'zsync delta not generated (zsyncmake missing?); auto-update will be slower.'
+  fi
+else
+  if ! "$appimagetool" "$APPDIR" "$OUT"; then
+    die "appimagetool failed to build the AppImage"
+  fi
 fi
 
 say "Done"

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -21,7 +21,7 @@
 # Shared maker signature:
 #   deb.sh <dist_dir> <version> <arch>
 #     <dist_dir>  staged electron-dist tree (default: build-linux/downloads/electron-dist)
-#     <version>   package version (default: $APP_VERSION env or 1.5.619)
+#     <version>   package version (default: $APP_VERSION env or 1.5.695)
 #     <arch>      deb-native arch: amd64 | arm64 (default: derived from host)
 # PACKAGE_NAME / WM_CLASS / MAINTAINER / DESCRIPTION come from the environment
 # (exported by build.sh); sane defaults apply when run standalone.
@@ -34,7 +34,7 @@ SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 #--- shared maker signature ----------------------------------------------------
 DIST="${1:-$PROJECT_ROOT/build-linux/downloads/electron-dist}"
-APP_VERSION="${2:-${APP_VERSION:-1.5.619}}"
+APP_VERSION="${2:-${APP_VERSION:-1.5.695}}"
 # Default deb arch from the host: dpkg knows the canonical name when present.
 _default_arch="amd64"
 if command -v dpkg >/dev/null 2>&1; then
@@ -106,7 +106,7 @@ source "\$app_dir/launcher-common.sh"
 
 # Handle --doctor before anything else.
 if [[ "\${1:-}" == '--doctor' ]]; then
-	run_doctor "\$helper_bin"
+	run_doctor "\$helper_bin" "\$electron_bin"
 	exit \$?
 fi
 

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -21,7 +21,7 @@
 # Shared maker signature (see deb.sh / appimage.sh):
 #   rpm.sh <dist_dir> <version> <arch>
 #     <dist_dir>  staged electron-dist tree (default: build-linux/downloads/electron-dist)
-#     <version>   package version (default: $APP_VERSION env or 1.5.619)
+#     <version>   package version (default: $APP_VERSION env or 1.5.695)
 #     <arch>      rpm-native arch: x86_64 | aarch64 (default: host uname -m)
 # PACKAGE_NAME / WM_CLASS / MAINTAINER / DESCRIPTION come from the environment
 # (exported by build.sh); sane defaults apply when run standalone.
@@ -34,7 +34,7 @@ SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 #--- shared maker signature ----------------------------------------------------
 DIST="${1:-$PROJECT_ROOT/build-linux/downloads/electron-dist}"
-APP_VERSION="${2:-${APP_VERSION:-1.5.619}}"
+APP_VERSION="${2:-${APP_VERSION:-1.5.695}}"
 ARCH="${3:-$(uname -m)}"
 
 # RPM Version: cannot contain a hyphen, so split a combined
@@ -88,6 +88,17 @@ rm -f "$APPDIR/resources/default_app.asar" "$APPDIR/electron" 2>/dev/null || tru
 rm -f "$APPDIR/resources/Release/Wispr Flow Helper.exe" 2>/dev/null || true
 chmod 0755 "$APPDIR/$NAME" "$APPDIR/resources/Release/wispr-flow-linux-helper"
 
+# Bake the chrome-sandbox setuid bit into the staging tree so the %files dir
+# walk records 4755 in the payload. Listing the file a second time under an
+# %attr(4755) entry (on top of the parent-dir listing) makes it appear twice;
+# on modern rpmbuild the "File listed twice" path can silently strip it from
+# the payload (cf. claude-desktop-debian #609), shipping an rpm whose sandbox
+# helper is missing or non-setuid. Set it here, list only the parent dir in
+# %files, and assert below that rpmbuild didn't warn.
+SANDBOX="$APPDIR/chrome-sandbox"
+[[ -f "$SANDBOX" ]] || die "chrome-sandbox not found at $SANDBOX (Electron dist incomplete)"
+chmod 4755 "$SANDBOX"
+
 say "Shared launcher library + doctor"
 cp "$SCRIPTS_DIR/launcher-common.sh" "$APPDIR/launcher-common.sh"
 cp "$SCRIPTS_DIR/doctor.sh" "$APPDIR/doctor.sh"
@@ -113,7 +124,7 @@ source "\$app_dir/launcher-common.sh"
 
 # Handle --doctor before anything else.
 if [[ "\${1:-}" == '--doctor' ]]; then
-	run_doctor "\$helper_bin"
+	run_doctor "\$helper_bin" "\$electron_bin"
 	exit \$?
 fi
 
@@ -212,6 +223,7 @@ Recommends:     xclip
 Recommends:     xsel
 
 %global __os_install_post %{nil}
+%global debug_package %{nil}
 %global _build_id_links none
 %global __brp_strip %{nil}
 %global __brp_strip_static_archive %{nil}
@@ -228,9 +240,12 @@ mkdir -p %{buildroot}
 cp -a "$PKGROOT"/. %{buildroot}/
 
 %files
+%defattr(-, root, root, -)
 /usr/bin/$NAME
+# /usr/lib/$NAME is listed once; chrome-sandbox's 4755 setuid bit was baked into
+# the FHS tree before the spec was written, so this dir walk records it (see the
+# chrome-sandbox staging note above; avoids the #609 "File listed twice" strip).
 /usr/lib/$NAME
-%attr(4755, root, root) /usr/lib/$NAME/chrome-sandbox
 /usr/share/applications/$NAME.desktop
 /usr/share/icons/hicolor/256x256/apps/$NAME.png
 /usr/share/icons/hicolor/scalable/apps/$NAME.svg
@@ -271,7 +286,24 @@ fi
 EOF
 
 say "Running rpmbuild"
-rpmbuild --define "_topdir $TOPDIR" --target "$ARCH" -bb "$SPEC"
+RPMBUILD_LOG="$WORK/rpmbuild.log"
+# Capture the build output so we can scan it for the #609 warning. set -e is
+# active, so temporarily relax it around the pipeline to read PIPESTATUS rather
+# than aborting before the diagnostic check.
+set +e
+rpmbuild --define "_topdir $TOPDIR" --target "$ARCH" -bb "$SPEC" 2>&1 \
+  | tee "$RPMBUILD_LOG"
+rpmbuild_rc=${PIPESTATUS[0]}
+set -e
+[[ $rpmbuild_rc -eq 0 ]] || die "rpmbuild failed (see $RPMBUILD_LOG)"
+
+# Guard against re-introducing the chrome-sandbox double-listing: a "File listed
+# twice" warning means %files has overlapping entries, and on modern rpmbuild
+# the silent-strip path can drop the setuid sandbox from the payload (#609).
+if grep -qF 'File listed twice' "$RPMBUILD_LOG"; then
+  grep -F 'File listed twice' "$RPMBUILD_LOG" >&2
+  die 'rpmbuild emitted "File listed twice" -- %files has overlapping listings (#609)'
+fi
 
 # rpmbuild names its output <name>-<Version>-<Release><dist>.<arch>.rpm (the
 # %{?dist} tag varies per host). Locate it by Version-Release...

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -25,7 +25,10 @@
 # Usage:   verify-patches.sh <path-to-app.asar>
 # Exit 0 = all markers present; exit 1 = at least one missing (build should fail).
 #===============================================================================
-set -euo pipefail
+# No `set -e` (project styleguide): the grep probes below intentionally tolerate
+# a no-match via `|| true` and accumulate into `missing`; status is checked
+# explicitly. `set -u` + pipefail still apply.
+set -uo pipefail
 
 ASAR="${1:-}"
 if [[ -z "$ASAR" || ! -f "$ASAR" ]]; then


### PR DESCRIPTION
## Summary

Aligns the build/packaging/release surface with the battle-tested
`claude-desktop-debian` reference — closing genuine regressions found in a
three-way comparison (packaging makers, build orchestration + launcher/doctor,
and the CI release chain) and adding the AppImage auto-update parity it has.

Scoped to **this repo only**. (The actual build-user-ownership `.deb` bug lives
in `claude-desktop-debian`, not here — wisprflow already builds with
`--root-owner-group` — so nothing in this PR touches that.)

## Changes

**Fixed**
- **rpm chrome-sandbox could be silently stripped** (`scripts/packaging/rpm.sh`):
  `%files` listed the sandbox twice (dir walk + an `%attr(4755)` entry); on
  rpmbuild 6.x the "File listed twice" path can drop it from the payload, leaving
  Electron unable to start sandboxed. The setuid bit is now baked into the FHS
  tree before the spec is written (single dir-walk listing records `4755`), the
  build log is captured, and the build fails hard on "File listed twice" (#609
  guard).
- **`build.sh --clean yes` was a no-op** — now prunes intermediate trees while
  preserving the produced package and the expensive `downloads/` tree.
- **Standalone `build-linux.sh` staged a stale version** — `APP_VERSION` default
  `1.5.619` → `1.5.695`, aligned across the makers/examples.

**Added**
- **`wispr-flow --doctor`**: chrome-sandbox (4755/root, AppImage-aware), Electron
  runtime, desktop-entry, and free-disk checks; `electron_bin` threaded into
  `run_doctor` in all three launchers.
- **AppImage auto-update**: CI embeds `gh-releases-zsync` update info + emits a
  `.AppImage.zsync` delta (build legs install `zsync` and collect the `.zsync`).

**Changed**
- `verify-patches.sh` drops `set -e` per the bash styleguide.
- rpm spec gains an explicit `%defattr` + `debug_package %{nil}`.
- README opening rewritten in the `claude-desktop-debian` declarative style;
  **Status** and **Supported environments** sections removed (their content lives
  in `docs/configuration.md`).

## Testing
- `bash -n` passes on all changed scripts.
- `shellcheck -S warning` clean on the changed scripts (only pre-existing SC2034
  globals in `build.sh` remain, unchanged by this PR).

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
90% AI / 10% Human
Claude: compared this repo against `claude-desktop-debian` across packaging,
orchestration, and CI; identified the regressions vs. intentional divergences;
implemented the fixes; wrote the changelog and this PR.
Human: requested the review, scoped which fixes to apply, and caught/reverted an
out-of-scope edit to the sibling repo.
