### PR TITLE
fix(packaging): force 0755 dir modes so resources/ is traversable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+### Fixed
+
+- Package shipped `resources/` and its subdirectories as `0700` root-only, so a
+  non-root user couldn't traverse them to reach `app.asar` or the helper and the
+  app crashed on launch. All three makers now force directories to `0755` after
+  staging; artifact tests assert `resources/` is other-traversable. (Regression
+  from the `%defattr(-, root, root, -)` change in v1.0.1.)
+
 ## [v1.0.1] - 2026-06-07
 
 ### Added

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -73,6 +73,12 @@ rsync -a \
   "$DIST/"/ "$APP_LIBDIR/" 2>/dev/null || cp -a "$DIST/." "$APP_LIBDIR/"
 rm -f "$APP_LIBDIR/resources/default_app.asar" "$APP_LIBDIR/electron" 2>/dev/null || true
 rm -f "$APP_LIBDIR/resources/Release/Wispr Flow Helper.exe" 2>/dev/null || true
+# Normalize directory modes. The staged dist carries restrictive dirs (asar
+# extraction leaves resources/ subtrees 0700) and rsync -a preserves them, so
+# a non-root user can't traverse into resources/ to reach app.asar or the
+# helper -- Electron then fails to launch. Files keep their copied modes; only
+# directories are forced world-traversable.
+find "$APP_LIBDIR" -type d -exec chmod 0755 {} +
 chmod 0755 "$APP_LIBDIR/$NAME" "$APP_LIBDIR/resources/Release/wispr-flow-linux-helper"
 
 say "Shared launcher library + doctor"

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -79,6 +79,12 @@ rsync -a \
   "$DIST/"/ "$APPDIR/" 2>/dev/null || cp -a "$DIST/." "$APPDIR/"
 rm -f "$APPDIR/resources/default_app.asar" "$APPDIR/electron" 2>/dev/null || true
 rm -f "$APPDIR/resources/Release/Wispr Flow Helper.exe" 2>/dev/null || true
+# Normalize directory modes. The staged dist carries restrictive dirs (asar
+# extraction leaves resources/ subtrees 0700) and rsync -a preserves them, so
+# a non-root user can't traverse into resources/ to reach app.asar or the
+# helper -- Electron then fails to launch. Files keep their copied modes; only
+# directories are forced world-traversable.
+find "$APPDIR" -type d -exec chmod 0755 {} +
 chmod 0755 "$APPDIR/$NAME" "$APPDIR/resources/Release/wispr-flow-linux-helper"
 
 say "Shared launcher library + doctor"

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -86,6 +86,12 @@ rsync -a \
 rm -f "$APPDIR/resources/default_app.asar" "$APPDIR/electron" 2>/dev/null || true
 # Drop the Windows helper if it lingered.
 rm -f "$APPDIR/resources/Release/Wispr Flow Helper.exe" 2>/dev/null || true
+# Normalize directory modes. The staged dist carries restrictive dirs (asar
+# extraction leaves resources/ subtrees 0700); rsync -a preserves them and
+# %defattr's dir field is '-' (keep), so a non-root user can't traverse into
+# resources/ to reach app.asar or the helper -- Electron then fails to launch.
+# Files keep their copied modes; only directories are forced world-traversable.
+find "$APPDIR" -type d -exec chmod 0755 {} +
 chmod 0755 "$APPDIR/$NAME" "$APPDIR/resources/Release/wispr-flow-linux-helper"
 
 # Bake the chrome-sandbox setuid bit into the staging tree so the %files dir

--- a/tests/test-artifact-common.sh
+++ b/tests/test-artifact-common.sh
@@ -51,6 +51,20 @@ assert_setuid() {
 	fi
 }
 
+# Assert $1 is traversable by "other" (o+rx). The test runs as root, for whom
+# -r/-x always pass, so check the mode bits directly. Guards the regression
+# where resources/ shipped 0700 and non-root users couldn't reach app.asar.
+assert_dir_traversable() {
+	local mode other
+	mode=$(stat -c '%a' "$1" 2>/dev/null)
+	other=$(( 0${mode: -1} ))
+	if (( (other & 5) == 5 )); then
+		pass "Directory other-traversable ($mode): $1"
+	else
+		fail "Directory not other-traversable ($mode): $1"
+	fi
+}
+
 # Assert $1 is a linux ELF (magic 7f 45 4c 46). Catches a Windows PE .node that
 # would dlopen-fail at startup ("invalid ELF header") -- the exact regression the
 # native-module staging guards against.
@@ -106,6 +120,12 @@ validate_app_contents() {
 
 	assert_file_exists "$resources_dir/app.asar"
 	assert_dir_exists "$resources_dir/app.asar.unpacked"
+
+	# resources/ and resources/Release/ must be traversable by non-root users:
+	# Electron runs as the user and reads app.asar / the helper from here. A
+	# 0700 dir here crashes launch even though the files inside are readable.
+	assert_dir_traversable "$resources_dir"
+	assert_dir_traversable "$resources_dir/Release"
 
 	# Unpacked native modules: better-sqlite3 + sqlite3 (rebuilt for Electron
 	# 42's V8 14.8) live under the unpacked .webpack tree and must ship as real


### PR DESCRIPTION
## Symptom

Wispr Flow **crashes on launch** after upgrading to v1.0.1 (rpm). `--doctor` reports the helper binary "not found", and `ls /usr/lib/wispr-flow/resources/` gives **Permission denied** for a non-root user.

## Root cause

The v1.0.1 package ships `resources/` and its subtrees as `drwx------` (0700, root:root). The files inside are world-readable, but a non-root user can't *traverse* the directories, so Electron (running as the user) can't read `app.asar` or the clean-room helper → crash.

Regression from #8, which changed the rpm spec to `%defattr(-, root, root, -)`. The `-` dir-mode field tells rpm to **preserve** the staged tree's directory modes, and the asar-extraction step leaves `resources/` subtrees at 0700. v1.0.0's `%defattr` forced 0755, which had masked it. The same `rsync -a` staging feeds the deb and appimage makers, so all three formats were exposed.

## Fix

- `rpm.sh` / `deb.sh` / `appimage.sh`: `find "$APPDIR" -type d -exec chmod 0755` after the dist copy. Files keep their copied modes; only directories change.
- Tests: new `assert_dir_traversable` helper; `validate_app_contents` now asserts `resources/` and `resources/Release/` are other-traversable, so this can't reship silently.

## Verification

- Local: `sudo chmod -R a+rX /usr/lib/wispr-flow/resources` makes the installed v1.0.1 launch and `--doctor` go all-green — confirms the diagnosis.
- `bats tests/` 84/84 pass; `shellcheck` clean on the touched scripts.

Ship as **v1.0.2** (v1.0.1 is already published; releases are append-only).

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>
80% AI / 20% Human
Claude: diagnosed the crash (0700 resources dir), traced it to the #8 %defattr change, fixed all three makers, added the regression test, verified locally.
Human: reported the crash and asked whether it was a permissions issue.