### PR TITLE
docs(changelog): cut v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+## [v1.0.2] - 2026-06-07
+
 ### Fixed
 
 - Package shipped `resources/` and its subdirectories as `0700` root-only, so a
@@ -50,6 +52,7 @@ Initial release — unofficial Linux repackaging of Wispr Flow (1.5.695) as
 (text injection, clipboard, global key capture), the Linux platform-gate
 patches, Nix flake, docs tree, and the tag-driven release/publish pipeline.
 
-[Unreleased]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.1+wispr1.5.695...HEAD
+[Unreleased]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.2+wispr1.5.695...HEAD
+[v1.0.2]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.1+wispr1.5.695...v1.0.2+wispr1.5.695
 [v1.0.1]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.0+wispr1.5.695...v1.0.1+wispr1.5.695
 [v1.0.0]: https://github.com/wispr-flow-linux/wispr-flow-linux/releases/tag/v1.0.0+wispr1.5.695


### PR DESCRIPTION
Promotes the `resources/` directory-permission fix (#10) from `[Unreleased]` to `[v1.0.2]` and adds the compare link.

After merge: `gh variable set REPO_VERSION 1.0.2` + tag `v1.0.2+wispr1.5.695` to trigger the publish chain.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>
90% AI / 10% Human
Claude: promoted the changelog entry and links.
Human: approved cutting v1.0.2.