### PR TITLE
feat(build): fetch the installer by default, --exe to override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+### Changed
+
+- `build.sh` now downloads the Wispr Flow installer from Wispr's official
+  endpoint by default (resolving it via `resolve-installer-url.sh`, the same path
+  CI uses), so `--exe` is no longer required. Pass `--exe <path>` to build
+  against a local installer instead. The auto-download verifies the resolved
+  version matches the pinned `APP_VERSION` and aborts on a mismatch.
+
 ## [v1.0.2] - 2026-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,22 +64,27 @@ Grab a `.deb`, `.rpm`, or `.AppImage` from the
 
 ## Building
 
-You supply the Wispr Flow installer, and the repo never bundles or commits it.
-Build a package with:
+By default `build.sh` downloads the Wispr Flow installer from Wispr's official
+endpoint at build time (the same source our [published releases](#installation)
+use); the repo never bundles or commits it. Build a package with:
 
 ```bash
-# Build an .rpm from a Wispr Flow installer you obtained yourself
+# Build an .rpm (downloads the installer automatically)
+./build.sh --build rpm
+
+# ...or point it at an installer you already have
 ./build.sh --build rpm --exe ~/Downloads/"Wispr Flow Setup-v1.5.695.exe"
 ```
 
-`--exe` is required. The pipeline never fetches, bundles, or hosts the
-proprietary installer.
+`--exe` is optional: without it, `build.sh` fetches the latest installer and
+verifies it matches the pinned version; with it, the build uses your local `.exe`
+and never fetches the proprietary app.
 
 Here are the common options (`./build.sh --help` lists all):
 
 - `-b, --build <deb|rpm|appimage|nix>` — package format (default: auto-detected)
 - `--arch <amd64|arm64>` — target architecture (default: host)
-- `-e, --exe <path>` — path to the installer .exe you supply (required)
+- `-e, --exe <path>` — installer .exe to use (optional; default: fetch latest)
 - `-c, --clean <yes|no>` — remove intermediate build files when done
 
 I cover prerequisites, the Linux Electron download, the native sqlite rebuild, and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,7 +21,7 @@ Before the first real release:
 
   ```bash
   gh variable set REPO_VERSION         --body "1.0.0"   # wrapper version
-  gh variable set WISPR_FLOW_VERSION   --body "1.5.619"  # tracked upstream version
+  gh variable set WISPR_FLOW_VERSION   --body "1.5.695"  # tracked upstream version
   ```
 
 - **Secrets**

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@
 #   parse_arguments
 #     --test-flags? -> print resolved flags + exit 0 (NO build)
 #   check_dependencies
-#   download_installer  (resolves --exe) -> staged installer
+#   download_installer  (--exe, else fetch latest) -> staged installer
 #   scripts/build-linux.sh           -> patch + native + stage (ARCH/version via env)
 #   fetch_electron (if not staged)   -> Linux Electron, launcher renamed wispr-flow
 #   run_packaging                    -> scripts/packaging/<fmt>.sh
@@ -251,7 +251,7 @@ print_resolved_flags() {
 	echo "Arch (electron):$electron_arch"
 	echo "Distro family:  $distro_family"
 	echo "Clean:          $clean_action"
-	echo "Exe:            ${local_exe_path:-<required: pass --exe>}"
+	echo "Exe:            ${local_exe_path:-<none: fetch latest upstream>}"
 	echo "Release tag:    ${release_tag:-<none>}"
 	echo "App version:    $APP_VERSION"
 	echo "Package version:$pkg_version"
@@ -281,8 +281,9 @@ main() {
 
 	check_dependencies
 
-	# Phase 2: resolve the --exe path, then 7z-extract it into the extract/
-	# tree that staging consumes (idempotent -- reuses a hand-prepared tree).
+	# Phase 2: resolve the installer (--exe, else fetch the latest upstream),
+	# then 7z-extract it into the extract/ tree that staging consumes
+	# (idempotent -- reuses a hand-prepared tree).
 	download_installer
 	extract_installer
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -2,12 +2,16 @@
 
 # Building from Source
 
-You build a local Wispr Flow for Linux package from a Wispr Flow Windows
-installer you supply yourself.
+You build a local Wispr Flow for Linux package from the Wispr Flow Windows
+installer. By default `build.sh` downloads it for you; pass `--exe` to use one
+you supply.
 
 ```bash
-# Build for your distro's native format (you supply the installer):
-./build.sh --build rpm --exe "/path/to/Wispr Flow Setup-v1.5.619.exe"
+# Build for your distro's native format (downloads the installer):
+./build.sh --build rpm
+
+# ...or supply your own installer:
+./build.sh --build rpm --exe "/path/to/Wispr Flow Setup-v1.5.695.exe"
 ```
 
 ## Prerequisites
@@ -39,27 +43,33 @@ that one isn't a system package you install ahead of time.
 
 ## Obtaining the installer
 
-This repo never downloads or commits the proprietary installer. You grab
+By default `build.sh` resolves and downloads the installer from Wispr's official
+endpoint (`scripts/setup/resolve-installer-url.sh`) — the same path CI uses. The
+proprietary installer is never committed to the repo.
+
+To build against a specific installer instead, grab
 `Wispr Flow Setup-v<version>.exe` from [wisprflow.ai](https://wisprflow.ai) and
-pass it with `--exe`. The pinned version is **1.5.619** (set in `build.sh` as
-`APP_VERSION`). I'd start there. A different installer version can drift the
-patch anchors, so it may need updates before it builds clean.
+pass it with `--exe`. The pinned version is **1.5.695** (set in `build.sh` as
+`APP_VERSION`); the auto-download verifies the upstream latest matches it and
+aborts on a mismatch, since a different installer version can drift the patch
+anchors.
 
 ## Building
 
-`--exe` is required. The build never fetches the proprietary installer, so you
-always point it at the one you supplied.
+By default `build.sh` fetches the latest installer; pass `--exe` to use your own.
 
 ```bash
-# Auto-detect format from your distro:
-./build.sh --exe "/path/to/Wispr Flow Setup-v1.5.619.exe"
+# Auto-detect format from your distro (downloads the installer):
+./build.sh
 
-# Or specify the format explicitly (still pass --exe):
-EXE="/path/to/Wispr Flow Setup-v1.5.619.exe"
-./build.sh --build deb      --exe "$EXE"   # Debian/Ubuntu .deb
-./build.sh --build rpm      --exe "$EXE"   # Fedora/RHEL .rpm
-./build.sh --build appimage --exe "$EXE"   # distribution-agnostic AppImage
-./build.sh --build nix                     # prints flake instructions (built via flake, not build.sh)
+# Supply your own installer:
+./build.sh --exe "/path/to/Wispr Flow Setup-v1.5.695.exe"
+
+# Or specify the format explicitly:
+./build.sh --build deb        # Debian/Ubuntu .deb
+./build.sh --build rpm        # Fedora/RHEL .rpm
+./build.sh --build appimage   # distribution-agnostic AppImage
+./build.sh --build nix        # prints flake instructions (built via flake, not build.sh)
 ```
 
 `build.sh` is a thin orchestrator over the validated staging engine
@@ -75,7 +85,7 @@ problem, the real work lives in those two layers underneath.
 |---|---|---|
 | `-b`, `--build` | `deb` `rpm` `appimage` `nix` | Output format. Defaults to your distro's native format. |
 | `--arch` | `amd64` `arm64` | Target architecture (overrides host detection). |
-| `-e`, `--exe` | path | Path to the Wispr Flow installer .exe you supply (**required**). |
+| `-e`, `--exe` | path | Installer .exe to use. Optional; default: fetch the latest from Wispr's endpoint. |
 | `-c`, `--clean` | `yes` `no` | Remove intermediate build files when done (default `no`). |
 | `-r`, `--release-tag` | string | Optional tag embedded in the package version. |
 | `--test-flags` | — | Parse + print the resolved flags, then exit **without** building. |

--- a/scripts/setup/detect-host.sh
+++ b/scripts/setup/detect-host.sh
@@ -191,8 +191,9 @@ Options:
                          (default: auto-detected from distro -> '$build_format')
       --arch <arch>      Target architecture: amd64 | arm64
                          (default: detected host arch -> '$arch')
-  -e, --exe <path>       Path to the Wispr Flow installer .exe you obtained
-                         yourself (REQUIRED -- the build never fetches it)
+  -e, --exe <path>       Path to a Wispr Flow installer .exe you obtained
+                         yourself (optional; default: fetch the latest installer
+                         from Wispr's official endpoint)
   -c, --clean <yes|no>   Remove intermediate build files when done (default: no)
   -r, --release-tag <t>  Optional release tag to embed in the package version
       --test-flags       Parse + print resolved flags, then exit WITHOUT building

--- a/scripts/setup/download.sh
+++ b/scripts/setup/download.sh
@@ -11,9 +11,10 @@
 # Sets globals:
 #   installer_exe_path   (path to the .exe used for this build)
 #
-# Network note: fetch_electron() performs real downloads. download_installer()
-# only resolves the --exe you supplied -- this pipeline never fetches the
-# proprietary app. Neither is exercised by --test-flags (build.sh exits first).
+# Network note: fetch_electron() and download_installer() perform real
+# downloads. download_installer() fetches the proprietary app from Wispr's
+# official endpoint unless you point it at a local --exe. Neither is exercised
+# by --test-flags (build.sh exits first).
 #===============================================================================
 
 # Pick an available downloader. Echoes "wget" or "curl"; dies if neither.
@@ -39,21 +40,24 @@ _fetch() {
 }
 
 #-------------------------------------------------------------------------------
-# download_installer -- resolve the user-supplied Wispr Flow Windows installer.
-#   * --exe is REQUIRED: this pipeline repackages an installer YOU obtained; it
-#     never fetches, bundles, or hosts the proprietary app. Build aborts if it
-#     is absent.
+# download_installer -- obtain the Wispr Flow Windows installer for this build.
+#   * --exe <path> supplied: repackage that local installer; no network fetch.
+#   * --exe absent (default): resolve the latest upstream URL and download it
+#     (see fetch_installer). The proprietary app is never bundled or committed
+#     to the repo -- it is fetched/supplied fresh each build.
 # A SHA-256 is verified IF one is known (WISPR_EXE_SHA256 env or installer.sha256
 # file). Upstream publishes no stable hash, so absence only warns.
 #-------------------------------------------------------------------------------
 download_installer() {
 	say 'Locate Wispr Flow installer'
 
-	[[ -n ${local_exe_path:-} ]] || die \
-		'No installer supplied. Pass --exe <path> with the Wispr Flow Setup .exe you obtained yourself.'
-	[[ -f $local_exe_path ]] || die "Local installer not found: $local_exe_path"
-	installer_exe_path="$local_exe_path"
-	auto "Using local installer: $installer_exe_path"
+	if [[ -n ${local_exe_path:-} ]]; then
+		[[ -f $local_exe_path ]] || die "Local installer not found: $local_exe_path"
+		installer_exe_path="$local_exe_path"
+		auto "Using local installer: $installer_exe_path"
+	else
+		fetch_installer
+	fi
 
 	# Optional SHA-256 verification.
 	local expected_sha=''
@@ -64,6 +68,44 @@ download_installer() {
 	fi
 	verify_sha256 "$installer_exe_path" "$expected_sha" 'Wispr Flow installer' \
 		|| die 'Installer checksum verification failed'
+}
+
+#-------------------------------------------------------------------------------
+# fetch_installer -- resolve the latest upstream installer URL and download it.
+# Used when --exe is not supplied. Mirrors what CI does, via the same
+# resolve-installer-url.sh helper. Guards that the resolved version matches the
+# pinned APP_VERSION (the version the Linux patches were verified against), so a
+# fetched build can't silently mislabel or run against an un-audited bundle; on
+# mismatch it aborts with guidance to pass --exe. The download is cached under
+# downloads/ and reused on re-runs.
+#-------------------------------------------------------------------------------
+fetch_installer() {
+	local resolver="$project_root/scripts/setup/resolve-installer-url.sh"
+	[[ -x $resolver ]] || die "installer resolver not found: $resolver"
+
+	auto 'No --exe supplied; resolving the latest Wispr Flow installer'
+	local resolved url version
+	resolved=$("$resolver") \
+		|| die 'Failed to resolve the Wispr Flow installer URL (pass --exe to use a local installer)'
+	url=$(printf '%s\n' "$resolved" | sed -nE 's/^URL=//p')
+	version=$(printf '%s\n' "$resolved" | sed -nE 's/^VERSION=//p')
+	[[ -n $url ]] || die 'installer resolver returned no URL'
+
+	if [[ -n $version && $version != "${APP_VERSION:-}" ]]; then
+		die "upstream latest is ${version} but this build is pinned to ${APP_VERSION}.
+Pass --exe with a ${APP_VERSION} installer, or update the pinned version first."
+	fi
+
+	local download_dir="$work_dir/downloads"
+	mkdir -p "$download_dir"
+	installer_exe_path="$download_dir/wispr-flow-setup-${APP_VERSION}.exe"
+	if [[ -f $installer_exe_path ]]; then
+		auto "Reusing cached installer: $installer_exe_path"
+	else
+		auto "Downloading installer: $url"
+		_fetch "$url" "$installer_exe_path" \
+			|| die "Failed to download installer from ${url}"
+	fi
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
## What

`build.sh` now downloads the Wispr Flow installer from Wispr's official endpoint by default, so `--exe` is no longer required for a local build. Pass `--exe <path>` to build against an installer you supply instead.

Previously `download_installer` aborted without `--exe` and never touched the network — building locally meant manually downloading the Windows installer first. CI already resolves + downloads it via `resolve-installer-url.sh`; this brings the same convenience to local builds, reusing that exact helper.

## How

- **`download_installer`** (`scripts/setup/download.sh`): use `--exe` when supplied; otherwise call the new **`fetch_installer`**, which runs `resolve-installer-url.sh`, downloads the resolved URL with the existing `_fetch` (wget/curl), and caches it under `downloads/`.
- **Version guard:** the resolved version must equal the pinned `APP_VERSION` (the version the Linux patches were verified against). On mismatch it aborts with guidance to pass `--exe`, so a fetched build can't silently mislabel or run against an un-audited bundle.
- Help text, `--test-flags` output (`Exe: <none: fetch latest upstream>`), and orchestration comments updated; `--exe` is now optional.
- Docs: README + `docs/building.md` rewritten for fetch-by-default (stale `1.5.619` examples bumped to `1.5.695`); `RELEASING.md` bootstrap example bumped.

## Verification

- `resolve-installer-url.sh` resolves to `VERSION=1.5.695` (matches the pin); the resolved URL returns HTTP 200 (~336 MB).
- `./build.sh --help` and `--test-flags` show the new optional-`--exe` wording.
- `shellcheck -x --severity=warning` clean; `bats tests/` 84/84.
- CI behavior unchanged — the release legs still pass `--exe wispr-flow-setup.exe` explicitly.

> Not run here: a full no-exe build (pulls the 336 MB installer + Electron + native rebuild). The fetch path is exercised piecewise (resolver, URL reachability, guard); `extract_installer` and everything downstream are unchanged.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-8> <noreply@anthropic.com>
85% AI / 15% Human
Claude: designed and implemented fetch_installer + the version guard, updated help/docs/changelog, verified resolver/URL/lint/tests.
Human: requested the feature (fetch by default, --exe override) and the PR.