### PR TITLE
fix(build): auto-fetch the prebuilt helper by default; fix readonly env pass-through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+### Fixed
+
+- Local builds failed at packaging with `Linux helper not staged` because the
+  prebuilt helper was only fetched in CI; staging now auto-fetches the release
+  pinned in `helper-version.txt` when `HELPER_BIN` is unset. An explicit
+  `HELPER_BIN` (e.g. a local helper build) is still honored and never fetched
+  over. (#15)
+- `build.sh` emitted `readonly variable` errors when dispatching staging:
+  `APP_VERSION`/`ELECTRON_VERSION` are readonly, so the command-prefix env
+  assignments were rejected and `build-linux.sh` silently fell back to its own
+  defaults. The version constants are now exported instead. (#15)
+
 ### Changed
 
 - The prebuilt native sqlite addons now build and release from their own repo

--- a/build.sh
+++ b/build.sh
@@ -44,6 +44,12 @@ export WM_CLASS
 readonly APP_VERSION='1.5.695'
 readonly ELECTRON_VERSION='42.3.0'
 readonly ELECTRON_MAJOR='42'
+# Exported so scripts/build-linux.sh stages the versions the orchestrator
+# resolved (it defaults them when unset). They cannot be passed as
+# command-prefix assignments (VAR=x cmd): bash rejects a temporary assignment
+# to a readonly name, and the staging engine would silently fall back to its
+# own defaults.
+export APP_VERSION ELECTRON_VERSION ELECTRON_MAJOR
 # Exported so packaging makers (Phase 2 deb/appimage) can read them from the
 # environment; rpm.sh currently embeds its own metadata.
 readonly MAINTAINER='Wispr Flow Linux (unofficial)'
@@ -98,10 +104,10 @@ run_staging() {
 	say 'Stage app (patch + native + repack) via scripts/build-linux.sh'
 	chmod +x "$script_dir/scripts/build-linux.sh" || die 'cannot chmod build-linux.sh'
 	# build-linux.sh reads ARCH/APP_VERSION/ELECTRON_VERSION from the env (it
-	# defaults them when unset, preserving its standalone behavior).
+	# defaults them when unset, preserving its standalone behavior). The
+	# version constants reach it as exports (see the constants block); ARCH is
+	# per-invocation.
 	ARCH="$electron_arch" \
-	APP_VERSION="$APP_VERSION" \
-	ELECTRON_VERSION="$ELECTRON_VERSION" \
 		"$script_dir/scripts/build-linux.sh" \
 		|| die 'scripts/build-linux.sh staging failed'
 }
@@ -141,8 +147,10 @@ sync_stage_to_dist() {
 		auto 'Synced staged resources (app.asar + helper + native modules)'
 	else
 		warn "helper not present in staged tree ($helper)"
-		warn '  packaging will fail its helper check -- set HELPER_BIN and'
-		warn '  re-run staging (see helper-version.txt / wispr-flow-linux/helper).'
+		warn '  the staging auto-fetch failed (see warnings above) -- packaging'
+		warn '  will fail its helper check. Re-run with network access, or set'
+		warn '  HELPER_BIN to a local build (see helper-version.txt /'
+		warn '  wispr-flow-linux/helper).'
 	fi
 }
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -37,8 +37,9 @@ Format-specific (only the one you build):
 | `dpkg-deb` | `dpkg-dev` / `dpkg` | `--build deb` |
 | `rpmbuild` | `rpm` / `rpm-build` | `--build rpm` |
 
-You also need a **Rust toolchain** (`rustc` + `cargo`) for the helper. The
-native sqlite rebuild pulls `@electron/rebuild` via `npx` at build time, so
+A **Rust toolchain** (`rustc` + `cargo`) is only needed if you build the helper
+yourself from its repo; the build auto-fetches the prebuilt helper otherwise.
+The native sqlite rebuild pulls `@electron/rebuild` via `npx` at build time, so
 that one isn't a system package you install ahead of time.
 
 ## Obtaining the installer
@@ -115,9 +116,10 @@ unique to Wispr Flow. Its text-injection "Helper" process exists only as macOS
 (Swift) and Windows (C#) binaries, with no Linux variant and no source. A
 clean-room Rust helper
 ([github.com/wispr-flow-linux/helper](https://github.com/wispr-flow-linux/helper))
-reimplements it. This build no longer compiles the helper. It downloads the
-prebuilt binary pinned in `helper-version.txt`, staged via the `HELPER_BIN` env
-var, and patches the app to load it on Linux.
+reimplements it. This build no longer compiles the helper. By default it
+auto-fetches the prebuilt binary pinned in `helper-version.txt` and stages it;
+set `HELPER_BIN` to use a local build instead (see below). The app bundle is
+patched to load it on Linux.
 
 Here's what the staging pipeline (`scripts/build-linux.sh`) does:
 
@@ -147,13 +149,35 @@ broken. I added that gate after getting burned by a silently-incomplete patch.
 
 ## Manual / network-dependent steps
 
-Two steps need network + toolchain, so they can't run fully offline:
+Three steps need network + toolchain, so they can't run fully offline:
 
 ### Linux Electron download
 
 The build fetches **Electron 42.3.0** for `linux-x64` (or `linux-arm64`) from
 the upstream releases. `scripts/setup/fetch-electron-binary.js` drives this, so
 you don't pick the runtime by hand.
+
+### The clean-room helper (prebuilt, with a `HELPER_BIN` override)
+
+The helper is consumed like the native modules: a prebuilt release asset pinned
+in `helper-version.txt`. When `HELPER_BIN` is unset, staging auto-fetches that
+tag from the [helper repo](https://github.com/wispr-flow-linux/helper)'s
+releases into `helper-bin/` via `scripts/setup/fetch-helper-bin.sh` — no env
+var, no manual step.
+
+To use a local build instead (e.g. while hacking on the helper), point
+`HELPER_BIN` at it:
+
+```bash
+HELPER_BIN=/path/to/helper/target/release/wispr-flow-linux-helper \
+  ./build.sh --build deb
+```
+
+An explicit `HELPER_BIN` is always respected: if it points at a missing or
+non-executable file the build warns and does **not** fetch over it, and
+packaging then refuses the helper-less tree. Offline, you can also pre-drop a
+binary at `helper-bin/wispr-flow-linux-helper` — an existing executable there
+is used as-is.
 
 ### Native sqlite modules (prebuilt, with an opt-in local rebuild)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -204,6 +204,38 @@ the a11y bus as unreachable, odds are the AT-SPI registry just isn't running on
 your compositor. [configuration.md](configuration.md#at-spi-accessibility) has
 the details.
 
+## "ERROR: Linux helper not staged at resources/Release/wispr-flow-linux-helper"
+
+A `./build.sh` run fails in the packaging step with this error (often after a
+`helper not present in staged tree` warning during the resources sync).
+
+### Fix
+
+The packaging makers refuse to ship a tree without the helper, and staging
+didn't get one. Staging auto-fetches the prebuilt helper pinned in
+`helper-version.txt` when `HELPER_BIN` is unset, so this means the fetch failed
+or an explicit `HELPER_BIN` pointed at a missing/non-executable file — scroll up
+to the `[WARN]` lines from Step 0 for which one.
+
+1. **Auto-fetch failed** (no network, or `gh`/`curl` unavailable) — restore
+   network access and re-run, or fetch by hand:
+
+   ```bash
+   scripts/setup/fetch-helper-bin.sh x86_64   # or aarch64
+   ./build.sh --build deb
+   ```
+
+2. **`HELPER_BIN` override is wrong** — the build respects an explicit override
+   and never fetches over it. Point it at a *built binary* (not a source
+   checkout), or unset it to auto-fetch:
+
+   ```bash
+   HELPER_BIN=/path/to/helper/target/release/wispr-flow-linux-helper \
+     ./build.sh --build deb
+   ```
+
+See the helper section of [building.md](building.md#the-clean-room-helper-prebuilt-with-a-helper_bin-override).
+
 ## More
 
 Curious which setups are actually validated, and which are only wired through?

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -31,9 +31,13 @@ RESOURCES_SRC="$NET45_DIR/resources"            # app.asar, app.asar.unpacked, R
 WEBPACK_MAIN="$EXTRACT_DIR/app/.webpack/main/index.js"   # unpacked main bundle (source of truth)
 
 # Clean-room Linux helper. It lives in its own repo
-# (github.com/wispr-flow-linux/helper); CI sets HELPER_BIN to a downloaded
-# prebuilt asset. Honor a pre-set env value first, else default to a local
-# helper-bin/ drop spot.
+# (github.com/wispr-flow-linux/helper) and is consumed as a prebuilt release
+# asset pinned in helper-version.txt. A pre-set HELPER_BIN (a local build, or
+# CI's prefetched asset) is honored as an override; otherwise the build
+# auto-fetches the pinned release into the local helper-bin/ drop spot
+# (resolve_helper_bin). Track whether the caller supplied a value so a bad
+# explicit override is reported instead of silently fetched over.
+HELPER_BIN_PRESET="${HELPER_BIN:+1}"
 HELPER_BIN="${HELPER_BIN:-$PROJECT_ROOT/helper-bin/wispr-flow-linux-helper}"
 
 # Linux-rebuilt native modules (better-sqlite3-multiple-ciphers + sqlite3). The
@@ -61,6 +65,54 @@ auto()  { printf '  \033[1;32m[AUTO]\033[0m   %s\n' "$*"; }
 manual(){ printf '  \033[1;33m[MANUAL]\033[0m %s\n' "$*"; }
 warn()  { printf '  \033[1;31m[WARN]\033[0m   %s\n' "$*"; }
 
+# Resolve the clean-room Linux helper into $HELPER_BIN, in priority order:
+#   1. already present + executable (a HELPER_BIN override pointing at a local
+#      build, a pre-drop into helper-bin/, or a previous fetch / re-run).
+#   2. HELPER_BIN was explicitly set but is missing/non-executable: respect the
+#      override -- warn and do NOT fetch over it.
+#   3. fetch the pinned prebuilt release asset (fetch-helper-bin.sh, tag in
+#      helper-version.txt) into the default helper-bin/ drop spot -- the
+#      normal, supported path for local builds. (CI prefetches the asset and
+#      sets HELPER_BIN itself, so it resolves at 1.)
+#   4. fetch failed:
+#      - in CI: hard-fail. A package without the helper is non-functional.
+#      - locally: warn and continue (preserves the offline dry-run behavior;
+#        the packaging makers refuse a helper-less tree, so nothing broken
+#        ships).
+resolve_helper_bin() {
+  if [[ -x "$HELPER_BIN" ]]; then
+    auto "Found Linux helper binary: $HELPER_BIN"
+    return 0
+  fi
+
+  if [[ $HELPER_BIN_PRESET == 1 ]]; then
+    warn "HELPER_BIN is set but not executable: $HELPER_BIN"
+    warn "  Respecting the override (not auto-fetching over it). Point it at a"
+    warn "  built helper (e.g. <helper checkout>/target/release/"
+    warn "  wispr-flow-linux-helper), or unset HELPER_BIN to auto-fetch the"
+    warn "  pinned prebuilt release (helper-version.txt)."
+    return 1
+  fi
+
+  auto "Fetching pinned prebuilt helper ($ARCH, tag in helper-version.txt)..."
+  if bash "$SCRIPT_DIR/setup/fetch-helper-bin.sh" "$ARCH" \
+      "$(dirname "$HELPER_BIN")" >/dev/null; then
+    auto "Fetched helper into $HELPER_BIN"
+    return 0
+  fi
+
+  warn "Could not fetch the pinned prebuilt helper (network? unpublished tag"
+  warn "  in helper-version.txt?)."
+  if [[ -n ${GITHUB_ACTIONS:-} || -n ${CI:-} ]]; then
+    warn "In CI: refusing to continue without the helper."
+    exit 1
+  fi
+  warn "  Build will continue and stage everything else; packaging will refuse"
+  warn "  a tree without the helper. Set HELPER_BIN to a local build, or re-run"
+  warn "  with network access to auto-fetch."
+  return 1
+}
+
 #===============================================================================
 # Step 0: preflight  [AUTO]
 #===============================================================================
@@ -82,15 +134,7 @@ step0_preflight() {
   if [[ -f "$RESOURCES_SRC/Release/Wispr Flow Helper.exe" ]]; then
     auto "Found Windows helper (will be replaced by the Linux helper): Release/Wispr Flow Helper.exe"
   fi
-  if [[ -x "$HELPER_BIN" ]]; then
-    auto "Found Linux helper binary: $HELPER_BIN"
-  else
-    warn "Linux helper binary not found/executable at $HELPER_BIN"
-    warn "  Get it from github.com/wispr-flow-linux/helper releases (pinned tag in"
-    warn "  helper-version.txt), or build a local checkout of that repo and set"
-    warn "  HELPER_BIN to its target/release/wispr-flow-linux-helper."
-    warn "  Build will continue and stage everything else; copy the helper in later."
-  fi
+  resolve_helper_bin
   if command -v node >/dev/null; then
     auto "node $(node --version)"
   else


### PR DESCRIPTION
Fixes #15

## Problem

A no-env-var `./build.sh --build deb|rpm` always failed at packaging with
`ERROR: Linux helper not staged at resources/Release/wispr-flow-linux-helper`.
`scripts/setup/fetch-helper-bin.sh` existed but was invoked **only** by the CI
workflows (`build-amd64.yml` / `build-arm64.yml` set `HELPER_BIN` themselves),
so a local build following `docs/building.md` staged everything except the
helper, warned, and then the maker hard-failed — exactly the reporter's log.

The same log also showed `./build.sh: line 102: APP_VERSION: readonly variable`:
`run_staging` passed the readonly version constants as command-prefix env
assignments, which bash rejects — `build-linux.sh` still ran but silently fell
back to its own internal version defaults.

## Fix

- **`scripts/build-linux.sh`** — new `resolve_helper_bin()` (mirrors
  `resolve_native_modules()`), called from preflight:
  1. an executable `HELPER_BIN` (CI's prefetched asset, a local build, or a
     pre-drop in `helper-bin/`) is used as-is;
  2. an explicitly set but missing/non-executable `HELPER_BIN` is reported and
     **never fetched over** (the override is respected);
  3. otherwise the release pinned in `helper-version.txt` is auto-fetched into
     `helper-bin/` via `fetch-helper-bin.sh`;
  4. fetch failure hard-fails in CI, warns-and-continues locally (the offline
     dry-run property is preserved; packaging still refuses a helper-less tree).
- **`build.sh`** — `APP_VERSION`/`ELECTRON_VERSION`/`ELECTRON_MAJOR` are now
  exported instead of passed as prefix assignments, so staging actually receives
  the orchestrator's versions; the stage-sync warning now points at the
  auto-fetch failure instead of a manual `HELPER_BIN` ritual.
- **Docs** — `building.md` gains "The clean-room helper (prebuilt, with a
  `HELPER_BIN` override)" and drops the stale Rust-toolchain prerequisite;
  `troubleshooting.md` gains the literal `Linux helper not staged` symptom
  entry; CHANGELOG updated under Unreleased.

## Verification

- `shellcheck -x --severity=warning` over the repo exactly as CI runs it: clean.
- All 84 bats tests pass.
- `resolve_helper_bin` exercised in a harness with a stubbed fetcher across all
  six paths (override-ok, override-broken→no fetch, cache hit, fetch-ok,
  fetch-fail local→warn+continue, fetch-fail CI→exit 1) — all behave as
  designed.
- Real end-to-end fetch of the pinned `v0.1.0` asset verified (x86_64 ELF,
  exec bit set); `helper-bin/` is already gitignored.
- Readonly repro: old prefix-assignment pattern leaves the child with the
  variable **unset** and still exits 0; the export pattern delivers it.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: root-cause diagnosis, resolve_helper_bin implementation, readonly fix, docs/changelog, test harness + verification
Human: directed the fix design (auto-fetch by default with a local-override env var), review