### PR TITLE
fix(build): refetch the cached helper when the pin moves past it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
   `APP_VERSION`/`ELECTRON_VERSION` are readonly, so the command-prefix env
   assignments were rejected and `build-linux.sh` silently fell back to its own
   defaults. The version constants are now exported instead. (#15)
+- A previously fetched helper in `helper-bin/` was reused forever, so bumping
+  `helper-version.txt` silently kept shipping the stale binary in local builds.
+  `fetch-helper-bin.sh` now stamps the fetched tag (`helper-bin/.tag`) and
+  staging refetches when the stamp disagrees with the pin. A manual pre-drop
+  (no stamp) and an explicit `HELPER_BIN` are still used as-is.
 
 ### Changed
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -175,9 +175,13 @@ HELPER_BIN=/path/to/helper/target/release/wispr-flow-linux-helper \
 
 An explicit `HELPER_BIN` is always respected: if it points at a missing or
 non-executable file the build warns and does **not** fetch over it, and
-packaging then refuses the helper-less tree. Offline, you can also pre-drop a
-binary at `helper-bin/wispr-flow-linux-helper` — an existing executable there
-is used as-is.
+packaging then refuses the helper-less tree.
+
+A fetched copy is stamped with its release tag (`helper-bin/.tag`), so when
+`helper-version.txt` is bumped the stale cache is refetched automatically on
+the next build. Offline, you can also pre-drop a binary at
+`helper-bin/wispr-flow-linux-helper` — an executable there without a stamp is
+treated as a deliberate local drop and used as-is.
 
 ### Native sqlite modules (prebuilt, with an opt-in local rebuild)
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -66,23 +66,43 @@ manual(){ printf '  \033[1;33m[MANUAL]\033[0m %s\n' "$*"; }
 warn()  { printf '  \033[1;31m[WARN]\033[0m   %s\n' "$*"; }
 
 # Resolve the clean-room Linux helper into $HELPER_BIN, in priority order:
-#   1. already present + executable (a HELPER_BIN override pointing at a local
-#      build, a pre-drop into helper-bin/, or a previous fetch / re-run).
-#   2. HELPER_BIN was explicitly set but is missing/non-executable: respect the
+#   1. an executable HELPER_BIN override (CI's prefetched asset or a local
+#      build) -- used as-is, never version-checked.
+#   2. an executable binary in the default helper-bin/ drop spot, IF it is not
+#      a stale fetch: fetch-helper-bin.sh stamps the downloaded tag into
+#      helper-bin/.tag, and a stamp that disagrees with helper-version.txt
+#      means the pin moved past the cache -- refetch. No stamp = a manual
+#      pre-drop (the documented offline path) -- used as-is.
+#   3. HELPER_BIN was explicitly set but is missing/non-executable: respect the
 #      override -- warn and do NOT fetch over it.
-#   3. fetch the pinned prebuilt release asset (fetch-helper-bin.sh, tag in
+#   4. fetch the pinned prebuilt release asset (fetch-helper-bin.sh, tag in
 #      helper-version.txt) into the default helper-bin/ drop spot -- the
-#      normal, supported path for local builds. (CI prefetches the asset and
-#      sets HELPER_BIN itself, so it resolves at 1.)
-#   4. fetch failed:
+#      normal, supported path for local builds.
+#   5. fetch failed:
 #      - in CI: hard-fail. A package without the helper is non-functional.
 #      - locally: warn and continue (preserves the offline dry-run behavior;
 #        the packaging makers refuse a helper-less tree, so nothing broken
 #        ships).
 resolve_helper_bin() {
+  local helper_dir pinned stamp
+  helper_dir="$(dirname "$HELPER_BIN")"
+
   if [[ -x "$HELPER_BIN" ]]; then
-    auto "Found Linux helper binary: $HELPER_BIN"
-    return 0
+    if [[ $HELPER_BIN_PRESET == 1 ]]; then
+      auto "Found Linux helper binary: $HELPER_BIN"
+      return 0
+    fi
+    pinned="$(tr -d '[:space:]' < "$PROJECT_ROOT/helper-version.txt" \
+      2>/dev/null)"
+    stamp=''
+    [[ -f "$helper_dir/.tag" ]] \
+      && stamp="$(tr -d '[:space:]' < "$helper_dir/.tag")"
+    if [[ -z $stamp || $stamp == "$pinned" ]]; then
+      auto "Found Linux helper binary: $HELPER_BIN"
+      return 0
+    fi
+    warn "Cached helper in $helper_dir was fetched as $stamp but"
+    warn "  helper-version.txt now pins $pinned -- refetching."
   fi
 
   if [[ $HELPER_BIN_PRESET == 1 ]]; then
@@ -107,9 +127,18 @@ resolve_helper_bin() {
     warn "In CI: refusing to continue without the helper."
     exit 1
   fi
-  warn "  Build will continue and stage everything else; packaging will refuse"
-  warn "  a tree without the helper. Set HELPER_BIN to a local build, or re-run"
-  warn "  with network access to auto-fetch."
+  if [[ -x "$HELPER_BIN" ]]; then
+    # Only reachable via the stale-stamp path: the old fetch is still in
+    # place, and Step 7 stages whatever executable sits at $HELPER_BIN.
+    warn "  The previously fetched ${stamp:-unknown} helper is still in place"
+    warn "  and WILL be staged -- the package will carry that stale helper,"
+    warn "  not the pinned ${pinned:-tag}. Re-run with network access to"
+    warn "  refetch."
+  else
+    warn "  Build will continue and stage everything else; packaging will"
+    warn "  refuse a tree without the helper. Set HELPER_BIN to a local build,"
+    warn "  or re-run with network access to auto-fetch."
+  fi
   return 1
 }
 

--- a/scripts/setup/fetch-helper-bin.sh
+++ b/scripts/setup/fetch-helper-bin.sh
@@ -11,7 +11,9 @@
 #   wispr-flow-linux-helper-aarch64   (arm64)
 #
 # This stages the matching asset into <dest>/wispr-flow-linux-helper, marks it
-# executable, and prints that absolute path to stdout (diagnostics go to stderr).
+# executable, stamps the fetched tag into <dest>/.tag (so the staging engine
+# can refetch when helper-version.txt moves past a cached copy), and prints
+# that absolute path to stdout (diagnostics go to stderr).
 # CI sets HELPER_BIN="$(scripts/setup/fetch-helper-bin.sh <arch>)" before
 # invoking build.sh.
 #
@@ -78,6 +80,11 @@ fi
 
 [[ -s $dest_bin ]] || die "downloaded helper is empty: ${dest_bin}"
 chmod 0755 "$dest_bin" || die "cannot chmod ${dest_bin}"
+
+# Stamp the tag this binary came from. resolve_helper_bin (build-linux.sh)
+# compares it against helper-version.txt and refetches a stale cache after a
+# pin bump; a manually pre-dropped binary has no stamp and is used as-is.
+printf '%s\n' "$tag" > "$dest_dir/.tag" || die "cannot write ${dest_dir}/.tag"
 
 log "Staged helper at ${dest_bin}"
 printf '%s\n' "$dest_bin"


### PR DESCRIPTION
Closes the cache gap left by #17: a previously fetched helper in `helper-bin/`
was reused forever, so a `helper-version.txt` bump (like #18's v0.1.1) silently
kept staging the stale binary in local builds. CI is unaffected — fresh runners
fetch every run.

## How it works

- `fetch-helper-bin.sh` stamps the tag it downloaded into `helper-bin/.tag`
  (written only after the binary lands and is chmod'd, so a failed transfer
  never gets a fresh stamp — the next run still detects the mismatch and
  refetches).
- `resolve_helper_bin` (staging preflight) compares the stamp against
  `helper-version.txt`: match → cache used; mismatch → warn + refetch.
- **No stamp = a deliberate manual pre-drop** (the documented offline path) —
  used as-is. An explicit `HELPER_BIN` override is likewise never
  version-checked or fetched over. Both behaviors from #17 are preserved.
- If the refetch fails locally while a stale binary is still in place, the
  warning now says that stale helper **will** be staged (previously the message
  wrongly claimed packaging would refuse the tree). In CI a fetch failure
  remains a hard fail.

`docs/building.md` documents the stamp semantics; CHANGELOG updated.

Known transition niggle: a helper fetched *before* this PR has no stamp, so it
reads as a pre-drop and is kept. One-time `rm -rf helper-bin/` clears it;
everything fetched from now on is stamped.

## Verification

- Harness over the extracted `resolve_helper_bin` with a stubbed fetcher:
  stamp-match → cache used; stamp-mismatch → refetched and `.tag` updated;
  no-stamp pre-drop → used as-is; explicit `HELPER_BIN` ignores a mismatched
  stamp; stale + fetch-fail → honest "will stage stale" warning; fresh +
  fetch-fail → original helper-less warning. All six as designed.
- `shellcheck -x --severity=warning` exactly as CI runs it: clean.
- All 84 bats tests pass.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: stamp design and implementation, message fixes, docs/changelog, harness verification
Human: identified the requirement (close the cache gap), design direction, review