### PR TITLE
fix(doctor): exec the helper instead of only stat-ing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ### Fixed
 
+- `wispr-flow --doctor` reported `Helper binary: present and executable` (and
+  an overall pass) for a helper that aborted on startup, because the check
+  only stat-ed the file. The doctor now execs the binary (`--version` probe
+  with stdin at EOF, 5s timeout, fd 3 discarded) and surfaces the captured
+  stderr — e.g. the loader's `GLIBC_2.39 not found` — on failure. (#16)
 - Local builds failed at packaging with `Linux helper not staged` because the
   prebuilt helper was only fetched in CI; staging now auto-fetches the release
   pinned in `helper-version.txt` when `HELPER_BIN` is unset. An explicit

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -12,7 +12,7 @@
 # Scoped to Wispr Flow's load-bearing runtime requirements: /dev/uinput
 # write access (keystroke injection), input-group fallback, wl-clipboard /
 # xclip-xsel, AT-SPI accessibility, the GNOME Shell window-bridge extension
-# (relogin caveat), helper-binary perms, and recent crashes.
+# (relogin caveat), the helper-binary launch probe, and recent crashes.
 #
 # To add a check: define `_check_<name>`, call it from run_doctor, and use
 # _pass / _fail / _warn / _info. _fail increments _doctor_failures (local to
@@ -285,7 +285,17 @@ _doctor_check_gnome_extension() {
 }
 
 #------------------------------------------------------------------------------
-# Helper binary — present at the expected resources path, executable.
+# Helper binary — present, executable, and actually launches. Stat checks
+# alone green-lit a helper that aborted at exec with `GLIBC_2.39 not found`
+# (wispr-flow-linux/helper#1, #16), so probe by running `--version` with
+# stdin at EOF:
+#   * helper >= v0.1.2 prints its version and exits 0
+#   * older helpers ignore argv, hit stdin EOF, and exit 0 silently
+#   * a binary that cannot start exits non-zero with the loader's
+#     message on stderr — surfaced below
+# fd 3 (the helper's IPC return channel) is redirected to /dev/null so a
+# probed helper can never write frames into a descriptor the launcher
+# happens to have open.
 #------------------------------------------------------------------------------
 _doctor_check_helper() {
 	local helper_path="${1:-}"
@@ -306,7 +316,38 @@ _doctor_check_helper() {
 		_info "Fix: chmod +x '$helper_path'"
 		return
 	fi
-	_pass "Helper binary: present and executable ($helper_path)"
+
+	local timeout_s="${WISPR_DOCTOR_HELPER_TIMEOUT:-5}"
+	local err_file probe_out status=0
+	err_file=$(mktemp "${TMPDIR:-/tmp}/wispr-doctor-helper.XXXXXX")
+	probe_out=$(timeout "$timeout_s" "$helper_path" --version \
+		</dev/null 2>"$err_file" 3>/dev/null) || status=$?
+
+	if [[ $status -eq 0 ]]; then
+		if [[ $probe_out == wispr-flow-linux-helper* ]]; then
+			_pass "Helper binary: launches OK ($probe_out)"
+		else
+			_pass "Helper binary: launches OK ($helper_path)"
+			_info 'Helper predates --version (< v0.1.2); no version reported.'
+		fi
+		rm -f "$err_file"
+		return
+	fi
+
+	if [[ $status -eq 124 ]]; then
+		_fail "Helper binary: still running after ${timeout_s}s probe" \
+			"at $helper_path"
+		_info 'The helper did not exit on stdin EOF; it may be wedged.'
+	else
+		_fail "Helper binary: cannot launch (exit $status) at $helper_path"
+		_info 'Text injection / push-to-talk will not work.'
+	fi
+	# Surface the launch-failure cause (e.g. `GLIBC_2.39 not found`).
+	local line
+	while IFS= read -r line; do
+		_info "stderr: $line"
+	done < <(tail -n 3 "$err_file")
+	rm -f "$err_file"
 }
 
 #------------------------------------------------------------------------------

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -224,18 +224,67 @@ command() {
 }
 
 # =============================================================================
-# _doctor_check_helper (path argument lets us drive it without a real binary)
+# _doctor_check_helper (path argument lets us drive it with stub scripts that
+# mimic the real helper's launch behaviors: print a version, exit silently on
+# stdin EOF, abort with a loader error on stderr, or hang)
 # =============================================================================
 
-@test "_doctor_check_helper: passes for an executable file" {
+@test "_doctor_check_helper: passes and reports the probed version" {
 	local helper="$TEST_TMP/wispr-flow-linux-helper"
-	printf '#!/bin/sh\n' > "$helper"
+	printf '#!/bin/sh\necho "wispr-flow-linux-helper 0.1.2"\n' > "$helper"
 	chmod +x "$helper"
 	_doctor_failures=0
 	run _doctor_check_helper "$helper"
 	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"wispr-flow-linux-helper 0.1.2"* ]]
 	_doctor_check_helper "$helper" >/dev/null
 	[[ $_doctor_failures -eq 0 ]]
+}
+
+@test "_doctor_check_helper: passes a pre---version helper (clean EOF exit)" {
+	# Helpers < v0.1.2 ignore argv, hit stdin EOF, and exit 0 silently.
+	local helper="$TEST_TMP/wispr-flow-linux-helper"
+	printf '#!/bin/sh\ncat >/dev/null\n' > "$helper"
+	chmod +x "$helper"
+	_doctor_failures=0
+	run _doctor_check_helper "$helper"
+	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"predates --version"* ]]
+	_doctor_check_helper "$helper" >/dev/null
+	[[ $_doctor_failures -eq 0 ]]
+}
+
+@test "_doctor_check_helper: fails and surfaces stderr when launch aborts" {
+	# The #16 blind spot: present + executable but aborts at startup
+	# (e.g. the dynamic loader's GLIBC version error on stderr).
+	local helper="$TEST_TMP/wispr-flow-linux-helper"
+	{
+		printf '#!/bin/sh\n'
+		printf 'echo "version GLIBC_2.39 not found" >&2\n'
+		printf 'exit 1\n'
+	} > "$helper"
+	chmod +x "$helper"
+	_doctor_failures=0
+	run _doctor_check_helper "$helper"
+	[[ $output == *"[FAIL]"* ]]
+	[[ $output == *"cannot launch"* ]]
+	[[ $output == *"GLIBC_2.39 not found"* ]]
+	_doctor_check_helper "$helper" >/dev/null
+	[[ $_doctor_failures -eq 1 ]]
+}
+
+@test "_doctor_check_helper: fails when the probe times out" {
+	local helper="$TEST_TMP/wispr-flow-linux-helper"
+	printf '#!/bin/sh\nsleep 30\n' > "$helper"
+	chmod +x "$helper"
+	export WISPR_DOCTOR_HELPER_TIMEOUT=1
+	_doctor_failures=0
+	run _doctor_check_helper "$helper"
+	[[ $output == *"[FAIL]"* ]]
+	[[ $output == *"still running"* ]]
+	_doctor_check_helper "$helper" >/dev/null
+	[[ $_doctor_failures -eq 1 ]]
+	unset WISPR_DOCTOR_HELPER_TIMEOUT
 }
 
 @test "_doctor_check_helper: fails when helper binary is missing" {


### PR DESCRIPTION
## Summary

Fixes #16.

`_doctor_check_helper` passed on any present + executable file, so a helper that aborted at launch — exactly wispr-flow-linux/helper#1's `GLIBC_2.39 not found` on Ubuntu 22.04 — still produced `[PASS] Helper binary: present and executable` and an overall green doctor while the app had no keyboard input.

The check now keeps the existing stat checks and then **execs the binary**:

```
timeout 5 "$helper_path" --version </dev/null 2>"$err_file" 3>/dev/null
```

- **Helper >= v0.1.2** (pinned since #20) prints its version → `[PASS] Helper binary: launches OK (wispr-flow-linux-helper 0.1.2)`.
- **Older helpers** ignore argv, hit stdin EOF, and exit 0 silently → still `[PASS]`, with an info note that the helper predates `--version`.
- **A binary that cannot start** exits non-zero → `[FAIL] Helper binary: cannot launch (exit N)` with the captured stderr tail (e.g. the loader's `GLIBC_2.39 not found` line) surfaced as `stderr:` info lines.
- **A probe that never exits** is killed by the timeout (exit 124) → `[FAIL] ... still running after 5s probe`. `WISPR_DOCTOR_HELPER_TIMEOUT` overrides the 5s (used by the tests).

fd 3 is explicitly discarded because the helper unconditionally takes ownership of fd 3 as its IPC return channel — a probed helper must never write frames into a descriptor the launcher happens to have open.

## Testing

- 4 new / updated bats tests cover the version-reporting pass, the pre-`--version` clean-EOF pass, the launch-abort FAIL with stderr surfacing, and the timeout FAIL. Full suite: 87/87 pass.
- `shellcheck` and `codespell` clean.
- Manual probe against a real helper v0.1.2 build: `[PASS] Helper binary: launches OK (wispr-flow-linux-helper 0.1.2)`.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
95% AI / 5% Human
Claude: probe design, implementation, tests, PR
Human: review, direction (issue #16 triage)