### PR TITLE
docs(changelog): cut v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+## [v1.0.3] - 2026-06-11
+
 ### Fixed
 
 - `wispr-flow --doctor` reported `Helper binary: present and executable` (and
@@ -95,7 +97,8 @@ Initial release — unofficial Linux repackaging of Wispr Flow (1.5.695) as
 (text injection, clipboard, global key capture), the Linux platform-gate
 patches, Nix flake, docs tree, and the tag-driven release/publish pipeline.
 
-[Unreleased]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.2+wispr1.5.695...HEAD
+[Unreleased]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.3+wispr1.5.751...HEAD
+[v1.0.3]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.2+wispr1.5.751...v1.0.3+wispr1.5.751
 [v1.0.2]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.1+wispr1.5.695...v1.0.2+wispr1.5.695
 [v1.0.1]: https://github.com/wispr-flow-linux/wispr-flow-linux/compare/v1.0.0+wispr1.5.695...v1.0.1+wispr1.5.695
 [v1.0.0]: https://github.com/wispr-flow-linux/wispr-flow-linux/releases/tag/v1.0.0+wispr1.5.695


### PR DESCRIPTION
## Summary

Promote `[Unreleased]` to `[v1.0.3] - 2026-06-11` ahead of tagging `v1.0.3+wispr1.5.751`, per [RELEASING.md](RELEASING.md).

Release contents: the local-build helper staging fixes (#15, #19), the `--doctor` helper launch probe (#16), the helper pin bumps to v0.1.1 (glibc 2.35 floor) and v0.1.2 (`--version`), the native-modules repo move, and fetching the official installer by default.

## Pre-release checklist

- CI green on `main` (last 5 runs pass).
- `bats tests/`: 87/87 pass locally; shellcheck + codespell clean.
- `WISPR_FLOW_VERSION` (1.5.751) matches `APP_VERSION` in `build.sh`.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
95% AI / 5% Human
Claude: changelog cut, checklist verification, PR
Human: release direction