### PR TITLE
fix: call setVisibleOnAllWorkspaces on Linux for overlay windows

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -277,6 +277,15 @@ step3_patch_bundle() {
     auto "Running linux-deeplink.sh on $target_bundle"
     bash "$SCRIPT_DIR/patches/linux-deeplink.sh" "$target_bundle" \
       || warn "Deep-link patch failed -- see linux-deeplink.sh output above."
+    # Call setVisibleOnAllWorkspaces on Linux for the four overlay windows (status
+    # indicator, overlay panel, context menu, calendar reminder). Without it, GNOME
+    # Wayland treats them as workspace-bound toplevels and they surface in the
+    # Alt+Tab switcher, interrupting dictation focus. The call is gated on isMac in
+    # the bundle; widening it to also run on Linux pins the windows as sticky system
+    # overlays (_NET_WM_STATE_STICKY on X11/XWayland; equivalent on Wayland).
+    auto "Running linux-overlay-visible.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-overlay-visible.sh" "$target_bundle" \
+      || warn "Overlay-visible patch failed -- see linux-overlay-visible.sh output above."
 
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"

--- a/scripts/patches/linux-overlay-visible.sh
+++ b/scripts/patches/linux-overlay-visible.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-overlay-visible.sh
+#
+# Calls setVisibleOnAllWorkspaces on Linux for the four overlay-type Wispr Flow
+# windows (status indicator, overlay panel, context menu, calendar reminder) in
+# the webpack-bundled Electron main process (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# The four overlay BrowserWindows (status indicator, overlay panel, context
+# menu, calendar reminder) each call:
+#
+#   <tD>&&<win>.setVisibleOnAllWorkspaces(!0,{visibleOnFullScreen:!0,
+#                                             skipTransformProcessType:!0})
+#
+# where `<tD>` is the module-level `isMac` boolean. On Linux — and on Windows —
+# this call is never made. On macOS it pins the window across all Mission
+# Control spaces and prevents it from surfacing in Exposé. On Linux/GNOME the
+# equivalent matters just as much:
+#
+#   * Without it, GNOME Wayland treats the status window as a
+#     workspace-bound toplevel. When the user switches apps, the window can
+#     appear in the Alt+Tab / Super+Tab switcher, interrupting dictation focus.
+#   * setVisibleOnAllWorkspaces(true) on Linux sets _NET_WM_STATE_STICKY
+#     (X11 / XWayland) and signals the Wayland compositor that the window
+#     should persist across virtual desktops. GNOME then excludes it from
+#     the application switcher and treats it as a persistent system overlay —
+#     exactly the behaviour the Mac version already gets.
+#
+# WHY ONLY 4 OF 5 SITES
+# ----------------------
+# There are five <tD>&&<win>.setVisibleOnAllWorkspaces(...skipTransformProcessType...)
+# calls in the bundle. The fifth is the meeting_recorder BrowserWindow — a real
+# interactive window that should NOT be sticky across workspaces. That site is
+# distinguished by the absence of a <win>.setFullScreenable(!1) call immediately
+# after the setVisibleOnAllWorkspaces call; the four overlay sites all have it.
+# The anchor below requires the trailing setFullScreenable, so the meeting
+# recorder is skipped by construction.
+#
+# THE FIX
+# -------
+# At each of the four overlay sites, widen the isMac predicate to also be true
+# on Linux:
+#
+#   <tD>&&<win>.setVisibleOnAllWorkspaces(...)
+#     becomes
+#   (<tD>||"linux"===process.platform)&&<win>.setVisibleOnAllWorkspaces(...)
+#
+# <tD> and <win> are minified symbols captured from the match — no minified
+# token is hardcoded. The anchor is the preserved developer method names
+# `setVisibleOnAllWorkspaces` + `skipTransformProcessType` (property names
+# survive minification) plus the required trailing `setFullScreenable(!1)`.
+#
+# Usage: linux-overlay-visible.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+LINUX_MARKER="WISPR_LINUX_OVERLAY_VISIBLE"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# Anchor: the four overlay-window sites have this exact shape:
+#   <tD>&&<win>.setVisibleOnAllWorkspaces(!0,{visibleOnFullScreen:!0,skipTransformProcessType:!0}),<win>.setFullScreenable(!1)
+#
+# Captures:
+#   tD  - the minified isMac flag (e.g. d.tD, ur.tD, s.tD, c.tD)
+#   win - the minified BrowserWindow variable (e.g. n, s)
+#
+# The trailing ,<win>.setFullScreenable(!1) is what excludes the meeting
+# recorder site (which has .webContents.on after setVisibleOnAllWorkspaces,
+# not setFullScreenable).
+site = re.compile(
+    r'(?P<tD>[\w$]+\.tD)'
+    r'(?P<vaw>&&(?P<win>[\w$]+)\.setVisibleOnAllWorkspaces\(!0,\{'
+    r'visibleOnFullScreen:!0,skipTransformProcessType:!0\}\))'
+    r'(?P<sfull>,(?P=win)\.setFullScreenable\(!1\))'
+)
+
+matches = list(site.finditer(data))
+
+EXPECTED = 4
+if len(matches) != EXPECTED:
+    sys.exit(
+        f"ERROR: expected exactly {EXPECTED} overlay setVisibleOnAllWorkspaces "
+        f"site(s) with trailing setFullScreenable, found {len(matches)}. "
+        f"Bundle layout may have changed; re-audit before patching."
+    )
+
+def widen(m):
+    return (
+        '(/*' + marker + '*/' + m.group('tD')
+        + '||"linux"===process.platform)'
+        + m.group('vaw')
+        + m.group('sfull')
+    )
+
+data, n = site.subn(widen, data)
+if n != EXPECTED:
+    sys.exit(f"ERROR: substitution applied {n} times (expected {EXPECTED}).")
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(f"Patched: widened {n} overlay setVisibleOnAllWorkspaces sites to also "
+      f"run on Linux (status, overlay panel, context menu, calendar reminder).")
+PY
+
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found)." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+if ! grep -qF '||"linux"===process.platform)&&' "$BUNDLE"; then
+	echo "ERROR: widened predicate not in expected form. Restoring backup." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+if command -v node >/dev/null; then
+	if ! node --check "$BUNDLE"; then
+		echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+		cp -p "$BUNDLE.orig" "$BUNDLE"
+		exit 1
+	fi
+	echo "node --check OK"
+fi
+
+echo "OK: overlay windows will call setVisibleOnAllWorkspaces on Linux in $BUNDLE"
+echo
+echo "Effect on Linux:"
+echo "  Status indicator, overlay panel, context menu, calendar reminder windows"
+echo "  now call setVisibleOnAllWorkspaces(true) on Linux — they will be"
+echo "  treated as sticky system overlays by GNOME/KDE and excluded from"
+echo "  the Alt+Tab switcher, matching macOS Mission Control behaviour."

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -11,6 +11,7 @@
 #     * mac-gates.sh           -> gates the macOS Applications-folder guard
 #     * linux-window-frame.sh  -> frameless hub/settings window on Linux
 #     * linux-deeplink.sh      -> cold-start wispr-flow: argv parse on Linux
+#     * linux-overlay-visible.sh -> setVisibleOnAllWorkspaces for overlay windows
 #   renderer bundles:
 #     * linux-renderer-chrome.sh -> remaps the <html> platform class linux->win32
 #     * linux-renderer-treat-as-windows.sh -> widens each renderer's isWindows
@@ -48,6 +49,7 @@ MARKERS=(
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
+  "overlay-visible: setVisibleOnAllWorkspaces on Linux for overlay windows|F|WISPR_LINUX_OVERLAY_VISIBLE"
 )
 
 missing=0


### PR DESCRIPTION
## Problem

On Linux/GNOME Wayland, the status indicator pill (and the overlay panel, context menu, and calendar reminder windows) appear in the **Alt+Tab / Super+Tab application switcher** when the user switches apps. This interrupts dictation focus — the status window shows up as a separate window entry and can steal focus, making the overlay behave like an annoying regular window rather than a silent system overlay.

Root cause: all four overlay `BrowserWindow` instances gate their `setVisibleOnAllWorkspaces` call on `isMac` (`tD`):

```js
d.tD && n.setVisibleOnAllWorkspaces(!0, {visibleOnFullScreen:!0, skipTransformProcessType:!0})
```

On Linux this call is never made. Without it, GNOME Wayland treats the windows as workspace-bound toplevels rather than sticky system overlays, so they surface in the switcher.

## Fix

Add `scripts/patches/linux-overlay-visible.sh`, a new build patch that widens the `isMac` predicate to also be true on `"linux" === process.platform` at the **four overlay-window sites** (status indicator, overlay panel, context menu, calendar reminder).

The meeting_recorder window — also in the bundle — is deliberately excluded. It is an interactive window and should not be sticky across workspaces. It is distinguishable from the overlay sites by the absence of an immediately-trailing `setFullScreenable(!1)` call; the anchor regex requires that call, so the meeting recorder is skipped by construction.

On Linux, `setVisibleOnAllWorkspaces(true)` sets `_NET_WM_STATE_STICKY` (X11/XWayland) and signals the Wayland compositor that the window should persist across virtual desktops as a system overlay — excluded from the Alt+Tab switcher, matching the macOS Mission Control behaviour these windows already get.

## Changes

- `scripts/patches/linux-overlay-visible.sh` — new patch script (same marker-verified, idempotent, `node --check`-validated style as existing patches)
- `scripts/build-linux.sh` — wired into Step 3 after `linux-deeplink.sh`
- `scripts/verify-patches.sh` — `WISPR_LINUX_OVERLAY_VISIBLE` marker registered so a half-patched asar fails the build

## Test plan

- [ ] Build a `.deb` with this patch applied
- [ ] Install on Ubuntu (GNOME Wayland session)
- [ ] Trigger dictation with the hotkey
- [ ] Switch between apps with Alt+Tab / Super+Tab — status pill should **not** appear in the switcher
- [ ] Status pill should remain visible above all windows as a true overlay
- [ ] Run `verify-patches.sh` against the repacked asar — should report `OK` for `WISPR_LINUX_OVERLAY_VISIBLE`
- [ ] Re-run the patch script on an already-patched bundle — should be a no-op (`Already patched`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)