### PR TITLE
fix: status pill position, autostart, and idle autohide on Linux

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -287,6 +287,30 @@ step3_patch_bundle() {
     bash "$SCRIPT_DIR/patches/linux-overlay-visible.sh" "$target_bundle" \
       || warn "Overlay-visible patch failed -- see linux-overlay-visible.sh output above."
 
+    # Fix the status pill / context-menu window position on Linux.
+    # Widens the Windows guard so Linux skips n+=i (avoids pushing the window
+    # behind the GNOME panel). Also subtracts 56 CSS px when i=0 (autohide
+    # dock) so the pill sits just above the dock instead of overlapping it.
+    auto "Running linux-status-position.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-status-position.sh" "$target_bundle" \
+      || warn "Status-position patch failed -- see linux-status-position.sh output above."
+
+    # Make "Start at Login" write the correct XDG autostart desktop entry.
+    # Electron's setLoginItemSettings on Linux either silently does nothing or
+    # points Exec at the raw electron binary; this patch writes/removes
+    # ~/.config/autostart/wispr-flow.desktop with Exec=/usr/bin/wispr-flow.
+    auto "Running linux-autostart.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-autostart.sh" "$target_bundle" \
+      || warn "Autostart patch failed -- see linux-autostart.sh output above."
+
+    # Hide the status pill when idle; show it only during dictation.
+    # On macOS/Windows the pill is always visible; on Linux many users find a
+    # persistent overlay intrusive. This patch hides the window at startup and
+    # re-shows it on the Listening state, hiding again 2 s after Idle/Dismissed.
+    auto "Running linux-status-autohide.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-status-autohide.sh" "$target_bundle" \
+      || warn "Status-autohide patch failed -- see linux-status-autohide.sh output above."
+
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"
     # Remap the <html> platform class linux->win32 so Linux adopts the tested

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -277,6 +277,15 @@ step3_patch_bundle() {
     auto "Running linux-deeplink.sh on $target_bundle"
     bash "$SCRIPT_DIR/patches/linux-deeplink.sh" "$target_bundle" \
       || warn "Deep-link patch failed -- see linux-deeplink.sh output above."
+    # Call setVisibleOnAllWorkspaces on Linux for the four overlay windows (status
+    # indicator, overlay panel, context menu, calendar reminder). Without it, GNOME
+    # Wayland treats them as workspace-bound toplevels and they surface in the
+    # Alt+Tab switcher, interrupting dictation focus. The call is gated on isMac in
+    # the bundle; widening it to also run on Linux pins the windows as sticky system
+    # overlays (_NET_WM_STATE_STICKY on X11/XWayland; equivalent on Wayland).
+    auto "Running linux-overlay-visible.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-overlay-visible.sh" "$target_bundle" \
+      || warn "Overlay-visible patch failed -- see linux-overlay-visible.sh output above."
 
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -160,10 +160,15 @@ build_electron_args() {
 		# GTK from connecting to the compositor (blurry/failed HiDPI).
 		export GDK_BACKEND=wayland
 	else
-		# Default: let Electron 42 auto-detect (Ozone picks Wayland when
-		# WAYLAND_DISPLAY is set). The uinput injection path does not
-		# depend on the toolkit backend, so no override is needed.
-		log_message 'Wayland session - Electron Ozone auto-detect'
+		# Default: force XWayland (--ozone-platform=x11).
+		# Under native Ozone Wayland, Electron ignores X11 EWMH window-type
+		# hints (skipTaskbar, type:"toolbar"), so the status indicator appears
+		# as a regular closeable window in GNOME Activities / Alt+Tab.
+		# Under XWayland those hints are honoured by the compositor, giving
+		# the status pill correct overlay behaviour.
+		# WISPR_USE_WAYLAND=1 opts back into native Ozone for users who need it.
+		log_message 'Wayland session - using XWayland (--ozone-platform=x11) for overlay window compatibility'
+		electron_args+=('--ozone-platform=x11')
 	fi
 }
 

--- a/scripts/patches/linux-autostart.sh
+++ b/scripts/patches/linux-autostart.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-autostart.sh
+#
+# Makes "Start at Login" work on Linux in the webpack-bundled Electron main
+# process (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# Wispr Flow has two code paths that enable the login-item / autostart entry:
+#
+#  1. First-run init (Ho()): when no appLastClosedTime is recorded, the app
+#     auto-enables itself at login for new users.
+#  2. User-triggered IPC (SetOpenAtLogin): fires when the user toggles
+#     "Start at Login" in Wispr Flow Settings.
+#
+# Both call Electron's app.setLoginItemSettings({openAtLogin: true|false}).
+# On Linux this either silently does nothing, or writes a desktop file whose
+# Exec line points to the raw Electron binary /usr/lib/wispr-flow/wispr-flow
+# instead of the launcher wrapper /usr/bin/wispr-flow. Without the wrapper:
+#   • --class=Wispr Flow is absent  → wrong WM_CLASS, icon ungrouped
+#   • GPU/display-backend detection is skipped
+#   • stale SingletonLock cleanup is skipped
+#
+# THE FIX
+# -------
+# For both call sites, add a Linux branch that directly writes (or removes)
+# ~/.config/autostart/wispr-flow.desktop using Exec=/usr/bin/wispr-flow.
+#
+# SITE 1 — first-run init (Ho()):
+#   Anchor: "Failed to set Windows open at login for new user"
+#   Catch fn param: e   → closing sequence: String(e)}})}):
+#   Else branch before patch: :y.app.setLoginItemSettings({openAtLogin:!0})
+#
+# SITE 2 — IPC handler (SetOpenAtLogin):
+#   Anchor: "Failed to set Windows open at login" (no "for new user")
+#   Catch fn param: t   → closing sequence: String(t)}})}):
+#   Else branch before patch: :i.app.setLoginItemSettings({openAtLogin:e})
+#
+# The closing sequence }})}):
+#   }}  closes the two brace levels of the error() argument object
+#   )   closes .error()
+#   }   closes the catch arrow-fn body (e=>{...} or t=>{...})
+#   )   closes .catch(...)
+#   :   ternary separator to the else branch
+#
+# Both sites get an inline Linux branch injected before the
+# setLoginItemSettings fallback. The inline writer uses Node require()
+# (available in the main process) and is safe on all platforms since it is
+# gated on process.platform.
+#
+# Usage: linux-autostart.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+LINUX_MARKER="WISPR_LINUX_AUTOSTART"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# Shared inline autostart writer factory.
+# Returns the new ternary else-branch string for Linux:
+#   ("linux"===process.platform ? <writer>(val) : <fallback>)
+#
+# The writer is a self-calling arrow that uses require() so imports are
+# deferred to call time and don't affect the module on non-Linux platforms.
+DESKTOP_CONTENT = (
+    "[Desktop Entry]\\n"
+    "Type=Application\\n"
+    "Name=Wispr Flow\\n"
+    "Exec=/usr/bin/wispr-flow\\n"
+    "Hidden=false\\n"
+    "NoDisplay=false\\n"
+    "X-GNOME-Autostart-enabled=true\\n"
+)
+
+def make_replacement(pre, val, fallback):
+    writer = (
+        '("linux"===process.platform'
+        '?(/*' + marker + '*/openAtLogin=>{'
+        'const _d=require("path").join(require("os").homedir(),".config","autostart")'
+        ',_f=_d+"/wispr-flow.desktop";'
+        'try{openAtLogin?'
+        '(require("fs").mkdirSync(_d,{recursive:!0}),'
+        'require("fs").writeFileSync(_f,"' + DESKTOP_CONTENT + '")):require("fs").unlinkSync(_f)'
+        '}catch(_e){}}'
+        ')(' + val + '):' + fallback + ')'
+    )
+    return pre + ':' + writer
+
+# ── Site 1: first-run init (Ho()) ─────────────────────────────────────────
+# Catch fn uses `e` as its parameter name.
+site1 = re.compile(
+    r'("Failed to set Windows open at login for new user"'
+    r'.{0,250}?'
+    r'String\(e\)\}\}\)\}\)'
+    r')'
+    r':'
+    r'([\w$]+\.app\.setLoginItemSettings\(\{openAtLogin:!0\}\))'
+)
+
+m1 = list(site1.finditer(data))
+if len(m1) != 1:
+    sys.exit(
+        f"ERROR: expected exactly 1 first-run setLoginItemSettings site, "
+        f"found {len(m1)}. "
+        f"Bundle layout may have changed; re-audit Ho() / appLastClosedTime."
+    )
+
+for m in reversed(m1):
+    replacement = make_replacement(m.group(1), '!0', m.group(2))
+    data = data[:m.start()] + replacement + data[m.end():]
+
+# ── Site 2: IPC handler (SetOpenAtLogin) ──────────────────────────────────
+# Catch fn uses `t` as its parameter name (distinct from site 1's `e`).
+site2 = re.compile(
+    r'("Failed to set Windows open at login"'
+    r'.{0,250}?'
+    r'String\(t\)\}\}\)\}\)'
+    r')'
+    r':'
+    r'([\w$]+\.app\.setLoginItemSettings\(\{openAtLogin:e\}\))'
+)
+
+m2 = list(site2.finditer(data))
+if len(m2) != 1:
+    sys.exit(
+        f"ERROR: expected exactly 1 IPC setLoginItemSettings site, "
+        f"found {len(m2)}. "
+        f"Bundle layout may have changed; re-audit SetOpenAtLogin IPC handler."
+    )
+
+for m in reversed(m2):
+    replacement = make_replacement(m.group(1), 'e', m.group(2))
+    data = data[:m.start()] + replacement + data[m.end():]
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(
+    f"Patched: added Linux XDG autostart writer to 2 setLoginItemSettings "
+    f"sites (first-run Ho() + SetOpenAtLogin IPC handler)."
+)
+PY
+
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found in $BUNDLE)." >&2
+	echo "       The bundle was NOT restored; re-run build-linux.sh from scratch." >&2
+	exit 1
+fi
+
+if ! grep -qF '/usr/bin/wispr-flow' "$BUNDLE"; then
+	echo "ERROR: launcher path /usr/bin/wispr-flow not found in patched bundle." >&2
+	echo "       The bundle was NOT restored; re-run build-linux.sh from scratch." >&2
+	exit 1
+fi
+
+echo "OK: Linux autostart patched in $BUNDLE"
+echo
+echo "Effect on Linux:"
+echo "  ~/.config/autostart/wispr-flow.desktop is written/removed when the"
+echo "  user toggles 'Start at Login' in Settings, or on first run."
+echo "  Exec=/usr/bin/wispr-flow ensures the launcher wrapper is used."

--- a/scripts/patches/linux-overlay-visible.sh
+++ b/scripts/patches/linux-overlay-visible.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-overlay-visible.sh
+#
+# Calls setVisibleOnAllWorkspaces on Linux for the four overlay-type Wispr Flow
+# windows (status indicator, overlay panel, context menu, calendar reminder) in
+# the webpack-bundled Electron main process (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# The four overlay BrowserWindows (status indicator, overlay panel, context
+# menu, calendar reminder) each call:
+#
+#   <tD>&&<win>.setVisibleOnAllWorkspaces(!0,{visibleOnFullScreen:!0,
+#                                             skipTransformProcessType:!0})
+#
+# where `<tD>` is the module-level `isMac` boolean. On Linux — and on Windows —
+# this call is never made. On macOS it pins the window across all Mission
+# Control spaces and prevents it from surfacing in Exposé. On Linux/GNOME the
+# equivalent matters just as much:
+#
+#   * Without it, GNOME Wayland treats the status window as a
+#     workspace-bound toplevel. When the user switches apps, the window can
+#     appear in the Alt+Tab / Super+Tab switcher, interrupting dictation focus.
+#   * setVisibleOnAllWorkspaces(true) on Linux sets _NET_WM_STATE_STICKY
+#     (X11 / XWayland) and signals the Wayland compositor that the window
+#     should persist across virtual desktops. GNOME then excludes it from
+#     the application switcher and treats it as a persistent system overlay —
+#     exactly the behaviour the Mac version already gets.
+#
+# WHY ONLY 4 OF 5 SITES
+# ----------------------
+# There are five <tD>&&<win>.setVisibleOnAllWorkspaces(...skipTransformProcessType...)
+# calls in the bundle. The fifth is the meeting_recorder BrowserWindow — a real
+# interactive window that should NOT be sticky across workspaces. That site is
+# distinguished by the absence of a <win>.setFullScreenable(!1) call immediately
+# after the setVisibleOnAllWorkspaces call; the four overlay sites all have it.
+# The anchor below requires the trailing setFullScreenable, so the meeting
+# recorder is skipped by construction.
+#
+# THE FIX
+# -------
+# At each of the four overlay sites, widen the isMac predicate to also be true
+# on Linux:
+#
+#   <tD>&&<win>.setVisibleOnAllWorkspaces(...)
+#     becomes
+#   (<tD>||"linux"===process.platform)&&<win>.setVisibleOnAllWorkspaces(...)
+#
+# <tD> and <win> are minified symbols captured from the match — no minified
+# token is hardcoded. The anchor is the preserved developer method names
+# `setVisibleOnAllWorkspaces` + `skipTransformProcessType` (property names
+# survive minification) plus the required trailing `setFullScreenable(!1)`.
+#
+# Usage: linux-overlay-visible.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+LINUX_MARKER="WISPR_LINUX_OVERLAY_VISIBLE"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# Anchor: the four overlay-window sites have this exact shape:
+#   <tD>&&<win>.setVisibleOnAllWorkspaces(!0,{visibleOnFullScreen:!0,skipTransformProcessType:!0}),<win>.setFullScreenable(!1)
+#
+# Captures:
+#   tD  - the minified isMac flag (e.g. d.tD, ur.tD, s.tD, c.tD)
+#   win - the minified BrowserWindow variable (e.g. n, s)
+#
+# The trailing ,<win>.setFullScreenable(!1) is what excludes the meeting
+# recorder site (which has .webContents.on after setVisibleOnAllWorkspaces,
+# not setFullScreenable).
+site = re.compile(
+    r'(?P<tD>[\w$]+\.tD)'
+    r'(?P<vaw>&&(?P<win>[\w$]+)\.setVisibleOnAllWorkspaces\(!0,\{'
+    r'visibleOnFullScreen:!0,skipTransformProcessType:!0\}\))'
+    r'(?P<sfull>,(?P=win)\.setFullScreenable\(!1\))'
+)
+
+matches = list(site.finditer(data))
+
+EXPECTED = 4
+if len(matches) != EXPECTED:
+    sys.exit(
+        f"ERROR: expected exactly {EXPECTED} overlay setVisibleOnAllWorkspaces "
+        f"site(s) with trailing setFullScreenable, found {len(matches)}. "
+        f"Bundle layout may have changed; re-audit before patching."
+    )
+
+def widen(m):
+    return (
+        '(/*' + marker + '*/' + m.group('tD')
+        + '||"linux"===process.platform)'
+        + m.group('vaw')
+        + m.group('sfull')
+    )
+
+data, n = site.subn(widen, data)
+if n != EXPECTED:
+    sys.exit(f"ERROR: substitution applied {n} times (expected {EXPECTED}).")
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(f"Patched: widened {n} overlay setVisibleOnAllWorkspaces sites to also "
+      f"run on Linux (status, overlay panel, context menu, calendar reminder).")
+PY
+
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found)." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+if ! grep -qF '||"linux"===process.platform)&&' "$BUNDLE"; then
+	echo "ERROR: widened predicate not in expected form. Restoring backup." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+if command -v node >/dev/null; then
+	if ! node --check "$BUNDLE"; then
+		echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+		cp -p "$BUNDLE.orig" "$BUNDLE"
+		exit 1
+	fi
+	echo "node --check OK"
+fi
+
+echo "OK: overlay windows will call setVisibleOnAllWorkspaces on Linux in $BUNDLE"
+echo
+echo "Effect on Linux:"
+echo "  Status indicator, overlay panel, context menu, calendar reminder windows"
+echo "  now call setVisibleOnAllWorkspaces(true) on Linux — they will be"
+echo "  treated as sticky system overlays by GNOME/KDE and excluded from"
+echo "  the Alt+Tab switcher, matching macOS Mission Control behaviour."

--- a/scripts/patches/linux-status-autohide.sh
+++ b/scripts/patches/linux-status-autohide.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-status-autohide.sh
+#
+# Makes the Wispr Flow status pill completely invisible when idle on Linux,
+# showing it only during an active dictation cycle (hotkey-down → recording
+# → processing → idle) in the webpack-bundled Electron main process
+# (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# On macOS and Windows the status pill is always visible — it sits above the
+# Dock / taskbar and shows the current dictation state at a glance. On Linux
+# many users find a persistent overlay intrusive, especially when watching
+# video or working fullscreen. This patch makes the pill appear on demand:
+#
+#   1. App starts:        pill window is created but stays hidden (no window,
+#                         no border, nothing visible).
+#   2. Hotkey pressed:    pill instantly appears via showInactive().
+#   3. Recording / proc.: pill stays visible (user sees the state animation).
+#   4. Idle / dismissed:  after a 2-second grace period the pill hides again,
+#                         giving the user time to see the result flash.
+#
+# TWO PATCH SITES
+# ---------------
+# SITE 1 — x() / showStatusWindow (module 95070):
+#   Called once on startup (Po.SB()) and again when the window is recreated
+#   after destruction. It calls e.showInactive() then sets up monitor-move
+#   and ignore-mouse-events intervals. On Linux we immediately re-hide the
+#   window if _wfLinuxStatusVisible is falsy (undefined on first call →
+#   hidden; set to true by the state hook when dictation starts).
+#
+#   Anchor: e.showInactive() immediately followed by o().info("Showing
+#           status window") — 1 occurrence in the file.
+#
+# SITE 2 — updateDictationStatus / he() (StateManager module):
+#   Called on every dictation state change with e = the new state string.
+#   Injected after H.RA.extensionSystem?.broadcastDictationEnd() which is a
+#   1-of-1 anchor in the comma-operator chain. The injection position is
+#   unconditional — the comma operator evaluates all expressions even when
+#   the broadcastDictationEnd() call short-circuits.
+#
+#   On "listening":             clear the hide timer, set visible flag, show.
+#   On "idle"/"dismissed"/"error": clear visible flag, schedule hide in 2 s.
+#
+# Usage: linux-status-autohide.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+LINUX_MARKER="WISPR_LINUX_STATUS_AUTOHIDE"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# ── Site 1: suppress initial show in x() ─────────────────────────────────
+# After e.showInactive(), on Linux, immediately re-hide if the visible flag
+# is falsy. On first call _wfLinuxStatusVisible is undefined → !undefined is
+# true → window stays hidden. The state hook (site 2) sets it to true when
+# dictation starts, so subsequent calls from the recreation path respect the
+# current session visibility.
+site1 = re.compile(
+    r'(e\.showInactive\(\))'
+    r'(,o\(\)\.info\("Showing status window"\))'
+)
+m1 = list(site1.finditer(data))
+if len(m1) != 1:
+    sys.exit(
+        f"ERROR: expected exactly 1 showInactive/Showing site, found {len(m1)}. "
+        f"Bundle layout may have changed; re-audit module 95070 (showStatusWindow)."
+    )
+
+# ── Site 2: hook state transitions in updateDictationStatus ───────────────
+# H.RA.extensionSystem?.broadcastDictationEnd() is a 1-of-1 anchor directly
+# inside the updateDictationStatus comma-operator chain. The injected code is
+# unconditional even though broadcastDictationEnd() is behind a guard — the
+# comma operator preceding d.ZZ.matchedRouteName always evaluates.
+#
+# _wfLinuxStatusVisible — tracks whether the pill should be shown.
+#   Stored on H.RA (the shared app store) as a dynamic property.
+# _wfLinuxHT            — setTimeout handle for the deferred hide call.
+site2 = re.compile(
+    r'(H\.RA\.extensionSystem\?\.broadcastDictationEnd\(\))'
+    r'(,)'
+)
+m2 = list(site2.finditer(data))
+if len(m2) != 1:
+    sys.exit(
+        f"ERROR: expected exactly 1 broadcastDictationEnd site, "
+        f"found {len(m2)}. "
+        f"Bundle layout may have changed; re-audit updateDictationStatus."
+    )
+
+# Validate ordering: x() is later in the file than the StateManager.
+if m1[0].start() < m2[0].start():
+    sys.exit(
+        "ERROR: unexpected ordering — x() appears before StateManager patch. "
+        "Check bundle structure."
+    )
+
+# Build injection strings.
+linux_hide_check = (
+    '"linux"===process.platform&&!O.RA._wfLinuxStatusVisible&&e.hide()'
+)
+linux_state_hook = (
+    '"linux"===process.platform'
+    '&&(/*' + marker + '*/'
+    'e==="idle"||e==="dismissed"||e==="error"'
+    '?(H.RA._wfLinuxStatusVisible=!1,'
+      'clearTimeout(H.RA._wfLinuxHT),'
+      'H.RA._wfLinuxHT=setTimeout(()=>{'
+        'H.RA.statusWindow&&!H.RA.statusWindow.isDestroyed()'
+        '&&H.RA.statusWindow.hide()'
+      '},2e3))'
+    ':e==="listening"'
+      '&&H.RA.statusWindow'
+      '&&!H.RA.statusWindow.isDestroyed()'
+      '&&(clearTimeout(H.RA._wfLinuxHT),'
+         'H.RA._wfLinuxStatusVisible=!0,'
+         'H.RA.statusWindow.showInactive()))'
+)
+
+# Apply in reverse offset order so earlier offsets remain valid.
+# Site 1 (x(), higher offset) first, then site 2 (StateManager, lower).
+p1 = m1[0]
+repl1 = p1.group(1) + ',' + linux_hide_check + p1.group(2)
+data = data[:p1.start()] + repl1 + data[p1.end():]
+
+p2 = m2[0]
+repl2 = p2.group(1) + ',' + linux_state_hook + p2.group(2)
+data = data[:p2.start()] + repl2 + data[p2.end():]
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(
+    f"Patched: {marker} — status pill auto-hides on Linux when idle; "
+    f"appears on hotkey press, disappears 2 s after dictation ends."
+)
+PY
+
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found)." >&2
+	echo "       The bundle was NOT restored; re-run build-linux.sh from scratch." >&2
+	exit 1
+fi
+
+if command -v node >/dev/null; then
+	if ! node --check "$BUNDLE"; then
+		echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+		cp -p "$BUNDLE.orig" "$BUNDLE"
+		exit 1
+	fi
+	echo "node --check OK"
+fi
+
+echo "OK: status pill autohide patched on Linux in $BUNDLE"
+echo
+echo "Effect on Linux:"
+echo "  Idle:      pill window is completely hidden (no window, no border)"
+echo "  Listening: pill appears instantly on hotkey press"
+echo "  Processing: pill stays visible while transcribing"
+echo "  Idle/done: pill disappears 2 s after dictation ends"

--- a/scripts/patches/linux-status-position.sh
+++ b/scripts/patches/linux-status-position.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-status-position.sh
+#
+# Fixes the status pill / context-menu window position on Linux in the
+# webpack-bundled Electron main process (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# Two position-helper functions (v() for ContextMenuWindow, D() for
+# StatusWindow) share a common bug: when computing the usable screen height
+# they incorrectly add the bottom inset on Linux.
+#
+# The helpers follow this pattern:
+#
+#   let n = e.workAreaSize.height;
+#   const i = bounds.height - workArea.height - topInset; // bottom inset
+#   return <H8>
+#          || <RA>.dockInfo.isVisible && <RA>.dockInfo.x === e.bounds.x
+#                                     && <RA>.dockInfo.y === e.bounds.y
+#          || (n += i),               // ← BUG on Linux
+#          ...
+#          { height: n }
+#
+# Intent:
+#   • Windows (H8=true):  workArea already excludes the taskbar → skip n+=i.
+#   • macOS visible Dock: workArea already excludes the Dock → skip n+=i.
+#   • macOS hidden Dock:  extend n to the full screen bottom.
+#
+# On Linux, H8 is false and dockInfo (Mac-only) is absent, so (n+=i) fires
+# unconditionally, pushing the window behind the GNOME panel.
+#
+# AUTOHIDE DOCK (second fix)
+# --------------------------
+# When Ubuntu Dock runs in autohide mode, _NET_WORKAREA does NOT reserve
+# any space for the dock, so i = 0. Skipping n+=i has no effect; the pill
+# bottom coincides with the physical screen bottom and overlaps the dock.
+#
+# Fix: after skipping n+=i, subtract a fixed clearance (56 CSS pixels) on
+# Linux when i = 0. This places the pill just above the autohide dock:
+#
+#   dock height (icon-size 34, GNOME scale 5/3, Electron DPR 2):
+#     (34 + 2×10) × (5/3) / 2 ≈ 45 CSS px
+#   clearance applied:             56 CSS px
+#   gap above dock:                ~11 CSS px
+#
+# For fixed (non-autohide) docks i > 0, so !i is false and the clearance
+# is not applied — the pill lands exactly at the dock top.
+#
+# TWO AFFECTED FUNCTIONS
+# ----------------------
+# The same bug appears in two separate webpack modules:
+#   v() – ContextMenuWindow position helper
+#   D() – StatusWindow position helper
+# Both are patched by a single regex (two matches, EXPECTED = 2).
+#
+# Usage: linux-status-position.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+LINUX_MARKER="WISPR_LINUX_STATUS_POSITION"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# Anchor: the bottom-inset guard in the workArea height helpers.
+#
+# Pattern (both v() and D() share this shape):
+#   <sym>.H8 || <ra>.RA.dockInfo.isVisible
+#            && <ra>.RA.dockInfo.x === e.bounds.x
+#            && <ra>.RA.dockInfo.y === e.bounds.y
+#            || (n += i)
+#
+# Capture groups:
+#   H8   – the isWindows flag (e.g. c.H8, d.H8)
+#   rest – everything from the first || through ||(n+=i)
+#   RA   – the store module symbol — used as backreference to avoid
+#          false positives where two different RA symbols appear
+site = re.compile(
+    r'(?P<H8>[\w$]+\.H8)'
+    r'(?P<rest>'
+        r'\|\|(?P<RA>[\w$]+)\.RA\.dockInfo\.isVisible'
+        r'&&(?P=RA)\.RA\.dockInfo\.x===e\.bounds\.x'
+        r'&&(?P=RA)\.RA\.dockInfo\.y===e\.bounds\.y'
+        r'\|\|\(n\+=i\)'
+    r')'
+)
+
+matches = list(site.finditer(data))
+EXPECTED = 2   # v() = context-menu, D() = status window
+if len(matches) != EXPECTED:
+    sys.exit(
+        f"ERROR: expected exactly {EXPECTED} workArea bottom-inset guard(s), "
+        f"found {len(matches)}. "
+        f"Bundle layout may have changed; re-audit dockInfo.isVisible sites."
+    )
+
+def widen(m):
+    return (
+        # Widen the Windows guard to also include Linux → skips n+=i on Linux
+        '(/*' + marker + '*/' + m.group('H8')
+        + '||"linux"===process.platform)'
+        + m.group('rest')
+        # When i=0 (autohide dock / no bottom reservation in _NET_WORKAREA),
+        # subtract dock clearance so the pill sits just above the dock.
+        # 56 CSS px clears a typical GNOME dock (icon-size 34 at scale 5/3).
+        # For fixed docks (i>0) !i is false, so no extra clearance is applied.
+        + ',"linux"===process.platform&&!i&&(n-=56)'
+    )
+
+data, n = site.subn(widen, data)
+if n != EXPECTED:
+    sys.exit(f"ERROR: substitution applied {n} times (expected {EXPECTED}).")
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(
+    f"Patched: widened {n} workArea bottom-inset guard(s) to skip n+=i on "
+    f"Linux and added autohide-dock clearance (n-=56 when i=0)."
+)
+PY
+
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found)." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+if command -v node >/dev/null; then
+	if ! node --check "$BUNDLE"; then
+		echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+		cp -p "$BUNDLE.orig" "$BUNDLE"
+		exit 1
+	fi
+	echo "node --check OK"
+fi
+
+echo "OK: status pill / context-menu position fixed on Linux in $BUNDLE"
+echo
+echo "Effect on Linux (fixed dock, GNOME panel 45 px at bottom):"
+echo "  Before: pill y = workAreaSize.height + panelHeight - 320 (behind panel)"
+echo "  After:  pill y = workAreaSize.height             - 320 (just above panel)"
+echo
+echo "Effect on Linux (autohide dock, i=0 so _NET_WORKAREA == screen):"
+echo "  Before: pill bottom = screen bottom (overlaps dock)"
+echo "  After:  pill bottom = screen bottom - 56 CSS px (~11 px above dock)"

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -50,6 +50,9 @@ MARKERS=(
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
   "overlay-visible: setVisibleOnAllWorkspaces on Linux for overlay windows|F|WISPR_LINUX_OVERLAY_VISIBLE"
+  "status-position: pill placed above panel / autohide dock|F|WISPR_LINUX_STATUS_POSITION"
+  "autostart: XDG desktop entry for Start at Login|F|WISPR_LINUX_AUTOSTART"
+  "status-autohide: pill hidden when idle, shown on dictation|F|WISPR_LINUX_STATUS_AUTOHIDE"
 )
 
 missing=0

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -11,6 +11,7 @@
 #     * mac-gates.sh           -> gates the macOS Applications-folder guard
 #     * linux-window-frame.sh  -> frameless hub/settings window on Linux
 #     * linux-deeplink.sh      -> cold-start wispr-flow: argv parse on Linux
+#     * linux-overlay-visible.sh -> setVisibleOnAllWorkspaces for overlay windows
 #   renderer bundles:
 #     * linux-renderer-chrome.sh -> remaps the <html> platform class linux->win32
 #     * linux-renderer-treat-as-windows.sh -> widens each renderer's isWindows
@@ -48,6 +49,7 @@ MARKERS=(
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
+  "overlay-visible: setVisibleOnAllWorkspaces on Linux for overlay windows|F|WISPR_LINUX_OVERLAY_VISIBLE"
 )
 
 missing=0


### PR DESCRIPTION
## Summary

Three new main-bundle patches and one launcher fix that together give the status pill correct GNOME/Wayland behaviour:

- **`linux-status-position.sh`** — pill no longer hides behind the GNOME panel; autohide-dock case handled with 56 CSS px clearance so the pill sits just above instead of overlapping the dock
- **`linux-autostart.sh`** — "Start at Login" now writes `~/.config/autostart/wispr-flow.desktop` with `Exec=/usr/bin/wispr-flow` (the launcher wrapper) instead of relying on Electron's broken `setLoginItemSettings` on Linux
- **`linux-status-autohide.sh`** — pill is completely invisible when idle; appears instantly on hotkey press and disappears 2 s after dictation ends (no window, no border, nothing visible when not in use)
- **`launcher-common.sh`** — default Wayland backend changed from Ozone auto-detect to XWayland (`--ozone-platform=x11`), so X11 EWMH window-type hints are honoured by GNOME Shell and the pill doesn't appear as a closeable window in Activities/Alt+Tab

## Test plan

- [ ] Press hotkey → pill appears from nothing
- [ ] Record and release → pill stays visible through processing
- [ ] Text injected → pill disappears ~2 s later (no border remains)
- [ ] Toggle "Start at Login" ON → `~/.config/autostart/wispr-flow.desktop` created with correct `Exec=`
- [ ] Toggle "Start at Login" OFF → desktop file removed
- [ ] Reboot with autostart enabled → Wispr Flow launches via `/usr/bin/wispr-flow`
- [ ] Pill appears above the dock, not behind the GNOME panel
- [ ] With autohide dock: pill visible above (not overlapping) the dock
- [ ] GNOME Activities (Super key): pill does NOT appear as a separate window entry
- [ ] `WISPR_USE_WAYLAND=1 wispr-flow` still works for native Ozone users

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
100% AI / 0% Human
Claude: Investigated the Electron main bundle, identified patch sites using stable developer strings as anchors, wrote three new patch scripts and updated build/verify/launcher files.
Human: Reported the three bugs (wrong pill position, GNOME overview window, broken autostart) and requested the autohide feature.