### PR TITLE
fix: status pill hidden when idle + XWayland default for overlay compatibility

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -278,6 +278,14 @@ step3_patch_bundle() {
     bash "$SCRIPT_DIR/patches/linux-deeplink.sh" "$target_bundle" \
       || warn "Deep-link patch failed -- see linux-deeplink.sh output above."
 
+    # Hide the status pill when idle; show it only during dictation.
+    # On macOS/Windows the pill is always visible; on Linux many users find a
+    # persistent overlay intrusive. This patch hides the window at startup and
+    # re-shows it on the Listening state, hiding again 2 s after Idle/Dismissed.
+    auto "Running linux-status-autohide.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-status-autohide.sh" "$target_bundle" \
+      || warn "Status-autohide patch failed -- see linux-status-autohide.sh output above."
+
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"
     # Remap the <html> platform class linux->win32 so Linux adopts the tested

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -160,10 +160,15 @@ build_electron_args() {
 		# GTK from connecting to the compositor (blurry/failed HiDPI).
 		export GDK_BACKEND=wayland
 	else
-		# Default: let Electron 42 auto-detect (Ozone picks Wayland when
-		# WAYLAND_DISPLAY is set). The uinput injection path does not
-		# depend on the toolkit backend, so no override is needed.
-		log_message 'Wayland session - Electron Ozone auto-detect'
+		# Default: force XWayland (--ozone-platform=x11).
+		# Under native Ozone Wayland, Electron ignores X11 EWMH window-type
+		# hints (skipTaskbar, type:"toolbar"), so the status indicator appears
+		# as a regular closeable window in GNOME Activities / Alt+Tab.
+		# Under XWayland those hints are honoured by the compositor, giving
+		# the status pill correct overlay behaviour.
+		# WISPR_USE_WAYLAND=1 opts back into native Ozone for users who need it.
+		log_message 'Wayland session - using XWayland (--ozone-platform=x11) for overlay window compatibility'
+		electron_args+=('--ozone-platform=x11')
 	fi
 }
 

--- a/scripts/patches/linux-status-autohide.sh
+++ b/scripts/patches/linux-status-autohide.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-status-autohide.sh
+#
+# Makes the Wispr Flow status pill completely invisible when idle on Linux,
+# showing it only during an active dictation cycle (hotkey-down → recording
+# → processing → idle) in the webpack-bundled Electron main process
+# (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# On macOS and Windows the status pill is always visible — it sits above the
+# Dock / taskbar and shows the current dictation state at a glance. On Linux
+# many users find a persistent overlay intrusive, especially when watching
+# video or working fullscreen. This patch makes the pill appear on demand:
+#
+#   1. App starts:        pill window is created but stays hidden (no window,
+#                         no border, nothing visible).
+#   2. Hotkey pressed:    pill instantly appears via showInactive().
+#   3. Recording / proc.: pill stays visible (user sees the state animation).
+#   4. Idle / dismissed:  after a 2-second grace period the pill hides again,
+#                         giving the user time to see the result flash.
+#
+# TWO PATCH SITES
+# ---------------
+# SITE 1 — x() / showStatusWindow (module 95070):
+#   Called once on startup (Po.SB()) and again when the window is recreated
+#   after destruction. It calls e.showInactive() then sets up monitor-move
+#   and ignore-mouse-events intervals. On Linux we immediately re-hide the
+#   window if _wfLinuxStatusVisible is falsy (undefined on first call →
+#   hidden; set to true by the state hook when dictation starts).
+#
+#   Anchor: e.showInactive() immediately followed by o().info("Showing
+#           status window") — 1 occurrence in the file.
+#
+# SITE 2 — updateDictationStatus / he() (StateManager module):
+#   Called on every dictation state change with e = the new state string.
+#   Injected after H.RA.extensionSystem?.broadcastDictationEnd() which is a
+#   1-of-1 anchor in the comma-operator chain. The injection position is
+#   unconditional — the comma operator evaluates all expressions even when
+#   the broadcastDictationEnd() call short-circuits.
+#
+#   On "listening":             clear the hide timer, set visible flag, show.
+#   On "idle"/"dismissed"/"error": clear visible flag, schedule hide in 2 s.
+#
+# Usage: linux-status-autohide.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+LINUX_MARKER="WISPR_LINUX_STATUS_AUTOHIDE"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# ── Site 1: suppress initial show in x() ─────────────────────────────────
+# After e.showInactive(), on Linux, immediately re-hide if the visible flag
+# is falsy. On first call _wfLinuxStatusVisible is undefined → !undefined is
+# true → window stays hidden. The state hook (site 2) sets it to true when
+# dictation starts, so subsequent calls from the recreation path respect the
+# current session visibility.
+site1 = re.compile(
+    r'(e\.showInactive\(\))'
+    r'(,o\(\)\.info\("Showing status window"\))'
+)
+m1 = list(site1.finditer(data))
+if len(m1) != 1:
+    sys.exit(
+        f"ERROR: expected exactly 1 showInactive/Showing site, found {len(m1)}. "
+        f"Bundle layout may have changed; re-audit module 95070 (showStatusWindow)."
+    )
+
+# ── Site 2: hook state transitions in updateDictationStatus ───────────────
+# H.RA.extensionSystem?.broadcastDictationEnd() is a 1-of-1 anchor directly
+# inside the updateDictationStatus comma-operator chain. The injected code is
+# unconditional even though broadcastDictationEnd() is behind a guard — the
+# comma operator preceding d.ZZ.matchedRouteName always evaluates.
+#
+# _wfLinuxStatusVisible — tracks whether the pill should be shown.
+#   Stored on H.RA (the shared app store) as a dynamic property.
+# _wfLinuxHT            — setTimeout handle for the deferred hide call.
+site2 = re.compile(
+    r'(H\.RA\.extensionSystem\?\.broadcastDictationEnd\(\))'
+    r'(,)'
+)
+m2 = list(site2.finditer(data))
+if len(m2) != 1:
+    sys.exit(
+        f"ERROR: expected exactly 1 broadcastDictationEnd site, "
+        f"found {len(m2)}. "
+        f"Bundle layout may have changed; re-audit updateDictationStatus."
+    )
+
+# Validate ordering: x() is later in the file than the StateManager.
+if m1[0].start() < m2[0].start():
+    sys.exit(
+        "ERROR: unexpected ordering — x() appears before StateManager patch. "
+        "Check bundle structure."
+    )
+
+# Build injection strings.
+linux_hide_check = (
+    '"linux"===process.platform&&!O.RA._wfLinuxStatusVisible&&e.hide()'
+)
+linux_state_hook = (
+    '"linux"===process.platform'
+    '&&(/*' + marker + '*/'
+    'e==="idle"||e==="dismissed"||e==="error"'
+    '?(H.RA._wfLinuxStatusVisible=!1,'
+      'clearTimeout(H.RA._wfLinuxHT),'
+      'H.RA._wfLinuxHT=setTimeout(()=>{'
+        'H.RA.statusWindow&&!H.RA.statusWindow.isDestroyed()'
+        '&&H.RA.statusWindow.hide()'
+      '},2e3))'
+    ':e==="listening"'
+      '&&H.RA.statusWindow'
+      '&&!H.RA.statusWindow.isDestroyed()'
+      '&&(clearTimeout(H.RA._wfLinuxHT),'
+         'H.RA._wfLinuxStatusVisible=!0,'
+         'H.RA.statusWindow.showInactive()))'
+)
+
+# Apply in reverse offset order so earlier offsets remain valid.
+# Site 1 (x(), higher offset) first, then site 2 (StateManager, lower).
+p1 = m1[0]
+repl1 = p1.group(1) + ',' + linux_hide_check + p1.group(2)
+data = data[:p1.start()] + repl1 + data[p1.end():]
+
+p2 = m2[0]
+repl2 = p2.group(1) + ',' + linux_state_hook + p2.group(2)
+data = data[:p2.start()] + repl2 + data[p2.end():]
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(
+    f"Patched: {marker} — status pill auto-hides on Linux when idle; "
+    f"appears on hotkey press, disappears 2 s after dictation ends."
+)
+PY
+
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found)." >&2
+	echo "       The bundle was NOT restored; re-run build-linux.sh from scratch." >&2
+	exit 1
+fi
+
+if command -v node >/dev/null; then
+	if ! node --check "$BUNDLE"; then
+		echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+		cp -p "$BUNDLE.orig" "$BUNDLE"
+		exit 1
+	fi
+	echo "node --check OK"
+fi
+
+echo "OK: status pill autohide patched on Linux in $BUNDLE"
+echo
+echo "Effect on Linux:"
+echo "  Idle:      pill window is completely hidden (no window, no border)"
+echo "  Listening: pill appears instantly on hotkey press"
+echo "  Processing: pill stays visible while transcribing"
+echo "  Idle/done: pill disappears 2 s after dictation ends"

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -48,6 +48,7 @@ MARKERS=(
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
+  "status-autohide: pill hidden when idle, shown on dictation|F|WISPR_LINUX_STATUS_AUTOHIDE"
 )
 
 missing=0

--- a/tests/verify-patches.bats
+++ b/tests/verify-patches.bats
@@ -6,7 +6,7 @@
 # (the .asar stores the JS bundle as concatenated plaintext, so a byte-grep
 # finds the markers without unpacking).
 #
-# verify-patches.sh greps a fixed set of markers (8 fixed strings + 1 Perl
+# verify-patches.sh greps a fixed set of markers (9 fixed strings + 1 Perl
 # regex). We build a tiny fixture carrying those exact marker strings (PASS)
 # and per-marker fixtures that omit one (FAIL).
 #
@@ -37,6 +37,7 @@ declare -gA MARKER_SAMPLES=(
 	[windowframe]='"win32"===process.platform||"linux"===process.platform/*WISPR_LINUX_FRAMELESS*/&&Object.assign(t,{titleBarStyle:"hidden"});'
 	[treataswindows]='const x=((y?.platform?.isWindows??!1)||"linux"===y?.platform?.os)/*WISPR_LINUX_RENDERER_ISWIN*/;'
 	[deeplink]='if(f.H8||"linux"===process.platform){/*WISPR_LINUX_DEEPLINK*/const e=process.argv.find(x=>x.startsWith("wispr-flow:"));}'
+	[statusautohide]='"linux"===process.platform&&(/*WISPR_LINUX_STATUS_AUTOHIDE*/e==="idle"||e==="dismissed"||e==="error"?(H.RA._wfLinuxStatusVisible=!1,clearTimeout(H.RA._wfLinuxHT),H.RA._wfLinuxHT=setTimeout(()=>{H.RA.statusWindow&&!H.RA.statusWindow.isDestroyed()&&H.RA.statusWindow.hide()},2e3)):e==="listening"&&H.RA.statusWindow&&!H.RA.statusWindow.isDestroyed()&&(clearTimeout(H.RA._wfLinuxHT),H.RA._wfLinuxStatusVisible=!0,H.RA.statusWindow.showInactive()))'
 )
 
 # Write a fixture app.asar-like file containing every marker, except the one
@@ -149,6 +150,14 @@ write_fixture() {
 @test "verify: exits 1 when the deeplink marker is missing" {
 	local fixture
 	fixture="$(write_fixture deeplink)"
+	run "$VERIFY_SH" "$fixture"
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *'MISSING'* ]]
+}
+
+@test "verify: exits 1 when the status-autohide marker is missing" {
+	local fixture
+	fixture="$(write_fixture statusautohide)"
 	run "$VERIFY_SH" "$fixture"
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *'MISSING'* ]]


### PR DESCRIPTION
Two related launcher/overlay fixes:

**`linux-status-autohide.sh`** — Makes the status pill completely invisible when idle. The pill window starts hidden at launch and is shown via `showInactive()` on the Listening state, then hidden again 2 s after idle/dismissed/error. Uses two anchors: the `showInactive()` call in `x()` (module 95070) to suppress the initial show, and the `broadcastDictationEnd()` site in `updateDictationStatus()` for the state-change hook.

**`launcher-common.sh`** — Switches the default Wayland backend from Ozone auto-detect to XWayland (`--ozone-platform=x11`). Under native Ozone Wayland, Electron does not honour X11 EWMH window-type hints (`skipTaskbar`, `type:toolbar`), so the status pill appears as a closeable window in GNOME Activities. XWayland passes those hints to GNOME Shell, giving correct overlay behaviour. `WISPR_USE_WAYLAND=1` still opts into native Ozone.

Split from #25 as requested.