### PR TITLE
docs(troubleshooting): add PTT/shortcut-recorder section; clarify onboarding scope in --doctor

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,54 @@ It prints `[PASS]` / `[WARN]` / `[FAIL]` lines with inline fix commands, grouped
 The exit status is non-zero if any check FAILs. Do me a favor and attach the
 full output to bug reports — it's the single most useful thing you can hand me.
 
+## Push-to-talk doesn't fire / shortcut recorder captures no keystrokes (including during onboarding)
+
+The in-app shortcut recorder (including the one on the onboarding setup screen)
+and push-to-talk are both fed entirely by `KeypressEvent` frames the helper
+streams from the OS key layer. If those frames never arrive, the recorder shows
+nothing and captures nothing — the app has no other path for global hotkey input.
+
+The helper has two capture backends:
+
+- **evdev** (`/dev/input/event*`) — works on Wayland **and** X11. Needs read
+  access to the input devices.
+- **XInput2** — true X11 sessions only (not XWayland). Needs no device access.
+
+On **Wayland**, only evdev is available, and it needs the udev access grant.
+
+### Fix
+
+Run the built-in diagnostics first — the `Push-to-Talk (input monitor)` section
+will tell you exactly what's missing:
+
+```bash
+wispr-flow --doctor
+```
+
+If it prints `[FAIL] /dev/input: none of N event device(s) readable`, install
+the udev rule that grants your session access to input devices (this is a
+one-time step; it survives reboots):
+
+```bash
+wispr-flow --install-udev-rules
+```
+
+The command escalates via `pkexec` (graphical sudo prompt) or falls back to
+`sudo`. After it completes you may need to **log out and back in** (or replug
+your keyboard) for the new ACL to take effect on already-open devices. Then
+re-run `--doctor` to confirm the check passes and try the shortcut recorder
+again.
+
+Alternatively, if you're already a member of the `input` group (check with
+`id -nG | grep input`), just re-login — logind should grant uaccess on session
+start.
+
+> [!NOTE]
+> On **X11** the helper uses XInput2, which needs no device access at all. If
+> the shortcut recorder is still dead on X11 after confirming the helper is
+> running (`--doctor` shows the helper launch as OK), file a bug with the
+> full `--doctor` output.
+
 ## Paste does nothing / transcription doesn't get typed into my app
 
 This is the whole reason the app exists, so when it goes silent it hurts. In my

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -168,7 +168,8 @@ _doctor_check_input_read() {
 		return
 	fi
 	_fail "/dev/input: none of ${total} event device(s) readable"
-	_info 'Push-to-talk and the in-app shortcut recorder will not work.'
+	_info 'Push-to-talk and the in-app shortcut recorder will not work'
+	_info '(including the shortcut setup step during onboarding).'
 	_info 'Fix (easiest): wispr-flow --install-udev-rules  (installs the rule via pkexec/sudo)'
 	# shellcheck disable=SC2016  # literal $USER: copy-paste remedy
 	_info 'Fix (group, grants both input read + uinput write): sudo usermod -aG input "$USER"  (then re-login)'


### PR DESCRIPTION
## Problem

Users hit one of two symptoms with no visible explanation:

1. **Onboarding hangs silently at the shortcut-capture step** — the chord
   recorder shows nothing and captures nothing no matter what key they press.
2. **Push-to-talk never fires** after setup completes.

Both share the same root cause: the shortcut recorder and PTT are fed
**exclusively** by `KeypressEvent` frames the helper streams from the OS input
layer. The app has no other hotkey path. When the helper's evdev backend can't
open any `/dev/input/event*` device, those frames never arrive and both
features go dead — silently.

The existing `--doctor` output already prints a `[FAIL]` line for this, but the
description said _"Push-to-talk and the in-app shortcut recorder will not work"_
without mentioning the onboarding step. Users stuck on the onboarding screen had
no reason to connect it to a `--doctor` fix.

Related: #23 (udev rule split, portal-mode shortcut recording) and #33 (PTT
silently untriggerable on fresh installs).

---

## What changed

### `docs/troubleshooting.md`

New section: **"Push-to-talk doesn't fire / shortcut recorder captures no
keystrokes (including during onboarding)"**

- Explains that both features are driven entirely by `KeypressEvent` frames
  from the helper — there is no alternative input path in the app.
- Documents the two capture backends (evdev on Wayland+X11, XInput2 on X11
  only) so users understand why Wayland specifically needs the udev grant.
- Gives a concrete fix path: run `--doctor` → if the `/dev/input` check
  fails → run `--install-udev-rules` → log out/in if needed → re-run
  `--doctor` to confirm.
- Covers the group-membership shortcut (`input` group + re-login).
- Adds an X11 note: XInput2 needs no device access, so on X11 a dead recorder
  with a healthy helper is a genuine bug, not a permissions issue — file a
  report with full `--doctor` output.

The heading uses the literal user-visible symptoms (matching the project's
troubleshooting heading convention).

### `scripts/doctor.sh`

In `_doctor_check_input_read`, the single `[FAIL]` info line:

```
Push-to-talk and the in-app shortcut recorder will not work.
```

becomes two lines:

```
Push-to-talk and the in-app shortcut recorder will not work
(including the shortcut setup step during onboarding).
```

Users who run `--doctor` while stuck on the onboarding screen now see that the
fix applies to their exact situation without having to reach the docs first.

---

## Test plan

- [ ] `shellcheck scripts/doctor.sh` passes (no new warnings)
- [ ] `wispr-flow --doctor` on a system where `/dev/input` is unreadable
  prints the updated two-line message under the `[FAIL]` line
- [ ] `wispr-flow --doctor` on a system where `/dev/input` is readable shows
  `[PASS]` with no change to existing output
- [ ] Docs render correctly (admonition block, code fences, inline `id -nG`)
