### PR TITLE
fix: Hub window created unmanaged (override-redirect) on Linux X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+### Fixed
+
+- On X11 the Hub window opened as an unmanaged (override-redirect) window:
+  pinned above every other window, missing from Alt+Tab, and impossible to
+  move, minimize, or maximize. Upstream creates the window with `focusable:!1`
+  on every platform and only macOS restores focus later, so Linux inherited
+  Electron's override-redirect treatment of non-focusable windows. The new
+  `linux-hub-focusable.sh` patch rewrites the Hub config so `focusable` is
+  true on Linux only, leaving the shipped macOS and Windows behavior
+  untouched. (#36)
+
 ## [v1.0.3] - 2026-06-11
 
 ### Fixed

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -272,6 +272,14 @@ step3_patch_bundle() {
     auto "Running linux-window-frame.sh on $target_bundle"
     bash "$SCRIPT_DIR/patches/linux-window-frame.sh" "$target_bundle" \
       || warn "Window-frame patch failed -- see linux-window-frame.sh output above."
+    # Make the Hub window focusable on Linux: upstream creates it focusable:!1
+    # on every platform and only restores focus behind isMac gates. On X11 a
+    # focusable:false BrowserWindow is created override-redirect (unmanaged):
+    # always on top, no Alt+Tab/move/minimize (issue #36). See
+    # linux-hub-focusable.sh.
+    auto "Running linux-hub-focusable.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-hub-focusable.sh" "$target_bundle" \
+      || warn "Hub-focusable patch failed -- see linux-hub-focusable.sh output above."
     # Parse the wispr-flow: deep-link URL out of argv at cold start on Linux too
     # (the parse was win32-only; the warm-start second-instance path already works).
     auto "Running linux-deeplink.sh on $target_bundle"

--- a/scripts/patches/linux-hub-focusable.sh
+++ b/scripts/patches/linux-hub-focusable.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-hub-focusable.sh -- make the Flow Hub window focusable (and therefore
+# WM-managed) on Linux, in the webpack-bundled Electron main process
+# (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS (issue #36)
+# ---------------------------------
+# The Hub BrowserWindow config is created with `focusable:!1` on EVERY
+# platform:
+#
+#   const t={title:"Flow Hub",...,show:!1,...,webPreferences:{...,
+#     preload:require("path").resolve(__dirname,"../renderer","hub",
+#     "preload.js"),devTools:...},focusable:!1};
+#
+# macOS recovers: the focus-suppression helpers (`withHubFocusSuppressed` and
+# friends) toggle `setFocusable(!0)` back on behind an isMac gate. Windows
+# tolerates it (focusable:false only implies skipTaskbar there). Linux gets
+# NEITHER: per the Electron docs, `focusable:false` on Linux "makes the window
+# stop interacting with wm" -- the window is created as an X11
+# override-redirect (unmanaged) window. The result is exactly issue #36: the
+# Hub floats above every other window, has no Alt+Tab entry, and cannot be
+# moved, minimized, maximized, or switched away from on X11.
+#
+# THE PATCH (surgical, ONE property at the Hub window-config site)
+# ----------------------------------------------------------------
+# Rewrite the Hub config's `focusable:!1` to a platform expression:
+#
+#   focusable:!1
+#     becomes
+#   focusable:/*WISPR_LINUX_HUB_FOCUSABLE*/"linux"===process.platform
+#
+# Linux evaluates to `true` (normal, WM-managed, focusable window); darwin and
+# win32 evaluate to `false` -- behaviorally identical to the shipped `!1`, so
+# the macOS focus-suppression dance and the Windows treatment are unchanged.
+#
+# WHY ONLY THE HUB SITE
+# ---------------------
+# The 1.6.7 bundle has exactly THREE `focusable:!1` window configs:
+#   1. the floating overlay (status pill) -- intentionally non-focusable HUD
+#   2. the "Flow Context Menu" overlay    -- intentionally non-focusable;
+#      toggles setFocusable at runtime when opened
+#   3. the Hub                            -- the bug
+# The scratchpad window sets no `focusable` key (defaults true). We therefore
+# anchor on the Hub's OWN developer literals -- the `"hub","preload.js"`
+# preload path inside its webPreferences -- and touch nothing else.
+#
+# Anchor (unique in the bundle), keyed on stable developer string literals --
+# NOT on minified symbols (the config var and platform-flag symbols churn
+# every release):
+#   "hub","preload.js"),devTools:<no-braces>},focusable:!1}
+# The devTools value is captured as `[^{}]*` so the match cannot escape the
+# webPreferences object; if upstream ever puts braces in that expression or
+# moves `focusable` off the tail of the config, the EXPECTED count assertion
+# below fails loudly instead of patching the wrong site.
+#
+# Usage: linux-hub-focusable.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+	# default to the in-repo extracted bundle
+	BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+	BUNDLE="$(cd "$BUNDLE/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+	echo "ERROR: bundle not found: $BUNDLE" >&2
+	exit 1
+fi
+
+# --- Idempotency guard --------------------------------------------------------
+LINUX_MARKER="WISPR_LINUX_HUB_FOCUSABLE"
+if grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "Already patched ($LINUX_MARKER present in $BUNDLE) - nothing to do."
+	exit 0
+fi
+
+# --- Backup -------------------------------------------------------------------
+if [[ ! -f "$BUNDLE.orig" ]]; then
+	cp -p "$BUNDLE" "$BUNDLE.orig"
+	echo "Backup written: $BUNDLE.orig"
+fi
+
+# --- Patch (anchored on stable developer string literals) ---------------------
+python3 - "$BUNDLE" "$LINUX_MARKER" <<'PY'
+import sys, io, re
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# Anchor: the Hub renderer preload path (developer strings, minifier-stable)
+# through the end of webPreferences, then the `focusable:!1` that closes the
+# Hub config object. `[^{}]*` keeps the devTools expression from spanning into
+# another object; every minified identifier inside it is left uncaptured.
+site = re.compile(
+    r'("hub","preload\.js"\),devTools:[^{}]*\},)'  # g1: preload anchor ->
+    r'focusable:!1\}'                              #     webPreferences close
+)
+matches = list(site.finditer(data))
+
+# How many Hub window configs of this shape SHOULD exist. The 1.6.7 audit
+# found exactly one. If the bundle ever sprouts another (or the config shape
+# moves), EXPECTED must be bumped deliberately after re-auditing -- we do not
+# silently patch an unknown count.
+EXPECTED = 1
+if len(matches) != EXPECTED:
+    sys.exit(
+        f"ERROR: expected exactly {EXPECTED} Hub focusable window-config "
+        f"site(s), found {len(matches)}. Bundle layout may have changed; "
+        f"re-audit the \"hub\",\"preload.js\" / focusable:!1 sites before "
+        f"patching."
+    )
+
+# The marker comment lives inside the rewritten property value so the
+# idempotency grep and this site both key on the same insertion (a re-run
+# short-circuits on the marker grep; the original `focusable:!1` adjacency is
+# gone anyway).
+def fix(m):
+    return (
+        m.group(1)
+        + 'focusable:/*' + marker + '*/"linux"===process.platform}'
+    )
+
+data = site.sub(fix, data, count=EXPECTED)
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print(f"Patched: rewrote the Hub config's focusable:!1 to a linux-gated "
+      f"platform expression ({EXPECTED} site).")
+PY
+
+# --- Verify the result --------------------------------------------------------
+if ! grep -q "$LINUX_MARKER" "$BUNDLE"; then
+	echo "ERROR: post-patch verification failed (marker not found)." >&2
+	echo "       Restoring backup." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+# Confirm the rewritten property is well-formed: the marker must sit inside
+# the focusable value, followed by the linux platform test that closes the
+# Hub config object.
+if ! grep -qF \
+	'focusable:/*'"$LINUX_MARKER"'*/"linux"===process.platform}' \
+	"$BUNDLE"; then
+	echo "ERROR: rewritten property not in expected form. Restoring backup." >&2
+	cp -p "$BUNDLE.orig" "$BUNDLE"
+	exit 1
+fi
+
+# Syntax-check the patched bundle.
+if command -v node >/dev/null; then
+	if ! node --check "$BUNDLE"; then
+		echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+		cp -p "$BUNDLE.orig" "$BUNDLE"
+		exit 1
+	fi
+	echo "node --check OK"
+fi
+echo "OK: Hub window focusable-on-Linux rewrite applied in $BUNDLE"
+echo
+echo "Patched Hub window config now does (conceptually):"
+echo "  {title:'Flow Hub', ..., focusable: isLinux}   // was: focusable: false"
+echo
+echo "Linux gets a normal WM-managed, focusable, Alt+Tab-able Hub window;"
+echo "darwin/win32 still evaluate focusable:false exactly as shipped."

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -10,6 +10,7 @@
 #     * helper-env.sh          -> spreads session env into the helper spawn
 #     * mac-gates.sh           -> gates the macOS Applications-folder guard
 #     * linux-window-frame.sh  -> frameless hub/settings window on Linux
+#     * linux-hub-focusable.sh -> hub window focusable/WM-managed on Linux
 #     * linux-deeplink.sh      -> cold-start wispr-flow: argv parse on Linux
 #   renderer bundles:
 #     * linux-renderer-chrome.sh -> remaps the <html> platform class linux->win32
@@ -46,6 +47,7 @@ MARKERS=(
   "mac-gates: darwin gate before getAppPath|P|if\\(\"darwin\"!==process\\.platform\\)return!1;const[ ]*[\\w\$]+=[\\w\$]+\\.app\\.getAppPath"
   "renderer-chrome: linux->win32 platform-class remap|F|WISPR_LINUX_WIN32_CHROME"
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
+  "hub-focusable: linux hub window focusable/WM-managed|F|WISPR_LINUX_HUB_FOCUSABLE"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
 )

--- a/tests/linux-patches.bats
+++ b/tests/linux-patches.bats
@@ -1,9 +1,10 @@
 #!/usr/bin/env bats
 #
 # linux-patches.bats
-# Unit tests for the four renderer/main bundle patches added for the Linux port:
+# Unit tests for the five renderer/main bundle patches added for the Linux port:
 #   * linux-renderer-chrome.sh           -> remaps the <html> platform class linux->win32
 #   * linux-window-frame.sh              -> frameless hub/settings window on Linux
+#   * linux-hub-focusable.sh             -> hub window focusable/WM-managed on Linux
 #   * linux-renderer-treat-as-windows.sh -> widens each renderer's isWindows bind
 #                                           (bridge stays honest; no preload touched)
 #   * linux-deeplink.sh                  -> cold-start wispr-flow: argv parse on Linux
@@ -125,6 +126,43 @@ JS
 	run bash "$PATCH_DIR/linux-window-frame.sh" "$FIX"
 	[[ "$status" -ne 0 ]]
 	! grep -q 'WISPR_LINUX_FRAMELESS' "$FIX"
+}
+
+# =============================================================================
+# linux-hub-focusable.sh
+# =============================================================================
+
+@test "hub-focusable: rewrites the Hub focusable:!1, leaves overlays alone" {
+	cat > "$FIX" <<'JS'
+const t={title:"Flow Hub",center:!0,show:!1,webPreferences:{preload:require("path").resolve(__dirname,"../renderer","hub","preload.js"),devTools:"development"===_.M0||(0,N.Pv)(d.RA.prefs?.user.email||"")},focusable:!1};_.tD?Object.assign(t,{frame:!1,titleBarStyle:"hidden"}):Object.assign(t,{frame:!1,autoHideMenuBar:!0});
+const ov=new r.BrowserWindow({show:!1,transparent:!0,frame:!1,hasShadow:!1,focusable:!1,skipTaskbar:!0});
+JS
+	run bash "$PATCH_DIR/linux-hub-focusable.sh" "$FIX"
+	[[ "$status" -eq 0 ]]
+	grep -q 'WISPR_LINUX_HUB_FOCUSABLE' "$FIX"
+	# the Hub site now gates focusable on the platform
+	grep -qF 'focusable:/*WISPR_LINUX_HUB_FOCUSABLE*/"linux"===process.platform}' "$FIX"
+	# the overlay's intentional focusable:!1 is untouched (exactly one remains)
+	[[ "$(grep -c 'focusable:!1' "$FIX")" -eq 1 ]]
+	grep -qF 'hasShadow:!1,focusable:!1,skipTaskbar:!0' "$FIX"
+	node_check "$FIX"
+}
+
+@test "hub-focusable: idempotent on second run" {
+	cat > "$FIX" <<'JS'
+const t={title:"Flow Hub",center:!0,show:!1,webPreferences:{preload:require("path").resolve(__dirname,"../renderer","hub","preload.js"),devTools:"development"===_.M0},focusable:!1};
+JS
+	bash "$PATCH_DIR/linux-hub-focusable.sh" "$FIX"
+	assert_idempotent "$PATCH_DIR/linux-hub-focusable.sh" "$FIX"
+}
+
+@test "hub-focusable: bails non-zero when the Hub anchor is absent" {
+	cat > "$FIX" <<'JS'
+const ov=new r.BrowserWindow({show:!1,transparent:!0,frame:!1,hasShadow:!1,focusable:!1,skipTaskbar:!0});
+JS
+	run bash "$PATCH_DIR/linux-hub-focusable.sh" "$FIX"
+	[[ "$status" -ne 0 ]]
+	! grep -q 'WISPR_LINUX_HUB_FOCUSABLE' "$FIX"
 }
 
 # =============================================================================

--- a/tests/verify-patches.bats
+++ b/tests/verify-patches.bats
@@ -6,7 +6,7 @@
 # (the .asar stores the JS bundle as concatenated plaintext, so a byte-grep
 # finds the markers without unpacking).
 #
-# verify-patches.sh greps a fixed set of markers (8 fixed strings + 1 Perl
+# verify-patches.sh greps a fixed set of markers (9 fixed strings + 1 Perl
 # regex). We build a tiny fixture carrying those exact marker strings (PASS)
 # and per-marker fixtures that omit one (FAIL).
 #
@@ -35,6 +35,7 @@ declare -gA MARKER_SAMPLES=(
 	[helperenv]='stdio:["pipe","pipe","pipe","pipe"],env:{/*WISPR_LINUX_HELPER_ENV*/...process.env,sentryDSN:x}'
 	[chrome]='e.classList.add(/*WISPR_LINUX_WIN32_CHROME*/"linux"===w.electron.platform.os?"win32":w.electron.platform.os);'
 	[windowframe]='"win32"===process.platform||"linux"===process.platform/*WISPR_LINUX_FRAMELESS*/&&Object.assign(t,{titleBarStyle:"hidden"});'
+	[hubfocusable]='webPreferences:{preload:p("../renderer","hub","preload.js"),devTools:d},focusable:/*WISPR_LINUX_HUB_FOCUSABLE*/"linux"===process.platform};'
 	[treataswindows]='const x=((y?.platform?.isWindows??!1)||"linux"===y?.platform?.os)/*WISPR_LINUX_RENDERER_ISWIN*/;'
 	[deeplink]='if(f.H8||"linux"===process.platform){/*WISPR_LINUX_DEEPLINK*/const e=process.argv.find(x=>x.startsWith("wispr-flow:"));}'
 )
@@ -133,6 +134,14 @@ write_fixture() {
 @test "verify: exits 1 when the window-frame marker is missing" {
 	local fixture
 	fixture="$(write_fixture windowframe)"
+	run "$VERIFY_SH" "$fixture"
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *'MISSING'* ]]
+}
+
+@test "verify: exits 1 when the hub-focusable marker is missing" {
+	local fixture
+	fixture="$(write_fixture hubfocusable)"
 	run "$VERIFY_SH" "$fixture"
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *'MISSING'* ]]


### PR DESCRIPTION
## Summary

On X11 sessions the Hub window is created as an unmanaged (override-redirect)
window: pinned above every other window, missing from Alt+Tab, and impossible
to move, minimize, or maximize. During onboarding it covers the whole desktop
with no way to dismiss it. Fixes #36.

## Root cause

The Hub BrowserWindow config ships `focusable:!1` on every platform:

```js
const t={title:"Flow Hub",...,webPreferences:{...,preload:require("path")
  .resolve(__dirname,"../renderer","hub","preload.js"),...},focusable:!1};
```

macOS recovers because the focus-suppression helpers (`withHubFocusSuppressed`
and friends) toggle `setFocusable(!0)` back on behind an `isMac` gate. Windows
tolerates it. Linux gets neither: per the Electron docs, `focusable:false` on
Linux "makes the window stop interacting with wm", i.e. the window is created
override-redirect. Another `platform-gates.md` carve-out Linux falls through.

## Fix

New `scripts/patches/linux-hub-focusable.sh` rewrites the one Hub config site
(anchored on the `"hub","preload.js"` preload literal, EXPECTED=1 count
assertion, idempotency marker, `node --check`, backup/restore on failure):

```js
focusable:/*WISPR_LINUX_HUB_FOCUSABLE*/"linux"===process.platform
```

Linux evaluates to `true` (normal WM-managed window); darwin/win32 evaluate to
`false`, byte-identical to the shipped behavior. The other two `focusable:!1`
sites (floating overlay, Flow Context Menu) are intentionally non-focusable
HUDs and are left alone; the scratchpad window never sets `focusable`.

Wired into `build-linux.sh` after the window-frame patch; marker added to
`verify-patches.sh`; test groups added to `linux-patches.bats` (apply /
idempotent / bail-on-missing-anchor) and `verify-patches.bats`.

## Validation

Before (shipped 1.6.7 `.deb`, Ubuntu 24.04 GNOME Xorg):

```
xwininfo: Window id: 0x3e0000d "Hub"
  Override Redirect State: yes
```

The window is absent from `wmctrl -l` and `_NET_CLIENT_LIST_STACKING`.

After (locally built `.deb` from this branch):

```
xwininfo: Window id: 0x360000e "Hub"
  Override Redirect State: no
```

`wmctrl -l` lists the Hub, and moving, minimizing, maximizing, and Alt+Tab all
work; onboarding completed normally. Patch dry-run against the shipped
minified bytes matches exactly one site and re-runs as a no-op. Both bats
suites pass (30/30) and shellcheck is clean.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: diagnosis, patch, wiring, tests, changelog
Human: bug report, on-device validation, direction
