### PR TITLE
nix: fix fakeHash breaking nix build for helper fetch

### DIFF
--- a/nix/wispr-flow.nix
+++ b/nix/wispr-flow.nix
@@ -85,15 +85,14 @@ let
   # resources/Release/wispr-flow-linux-helper (mode 0755) where the patched
   # main bundle's 'linux' branch looks for it.
   #============================================================================
-  # NOTE: nix is unavailable in the environment this was wired up in, so the
-  # real fixed-output (FOD) hash for the GitHub fetch cannot be computed here.
-  # The first `nix build` WILL FAIL and print the correct `hash = ...`; paste
-  # that value over lib.fakeHash below.
+# Pinned FOD hash for the helper source fetch (v0.1.0). If the pin ever
+  # goes stale (e.g. the tag is moved), `nix build` will fail and print the
+  # correct `hash = ...` to paste in here.
   helperSrc = fetchFromGitHub {
     owner = "wispr-flow-linux";
     repo = "helper";
     rev = "v0.1.0";
-    hash = lib.fakeHash;
+    hash = "sha256-Teer9aJ7naKhZ3BOLSpOZSb48A7Ngsaq65ZJ3I14Bfc=";
   };
 
   linux-helper = rustPlatform.buildRustPackage {


### PR DESCRIPTION
[`nix/wispr-flow.nix` had `lib.fakeHash` committed for the `helperSrc`
fetchFromGitHub, per the comment above it — the maintainer's dev
environment didn't have `nix` available to compute the real hash before
committing.

This breaks `nix build` / `nix run` for every consumer with a fixed-output
derivation hash mismatch:

    error: hash mismatch in fixed-output derivation '...-source.drv':
      specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
      got:       sha256-Teer9aJ7naKhZ3BOLSpOZSb48A7Ngsaq65ZJ3I14Bfc=

This PR pins the real hash (the one Nix itself resolves for the `v0.1.0`
tag) and updates the now-stale comment.

Tested: verified the helperSrc fetch now resolves correctly with the
pinned hash (no more hash-mismatch error) by building with a dummy
WISPR_FLOW_EXE placeholder. Did not build the full package end-to-end,
since that requires a real Windows installer I didn't supply — but this
change only touches the helper fetch, which is unaffected by that step.](nix: fix fakeHash breaking nix build for helper fetch)