### PR TITLE
docs: add wl-copy hang to the paste troubleshooting causes

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -67,6 +67,49 @@ Run `--doctor` and work the failures top-down:
    uinput through logind (Arch is the one that caught me), so group membership
    is your grant path instead. Go back to step 1's `usermod` and relogin.
 
+4. **`wl-copy` hangs instead of returning (Wayland)** — `wl-clipboard` is
+   installed and `--doctor` is all-green, but the log shows `gRPC transcription
+   successful` followed by `PasteText: Request timed out`, and nothing reaches
+   the focused app. Check whether the clipboard tool returns at all:
+
+   ```bash
+   printf 'test' | timeout 4 wl-copy; echo "$?"   # 124 means it hung
+   pgrep -x wl-copy                               # stray copies piling up
+   ```
+
+   Mutter implements no data-control protocol, so `wl-clipboard` falls back to
+   mapping a surface that has to take keyboard focus before it can own the
+   selection. When that focus never lands, `wl-copy` never returns and
+   `PasteText` times out behind it. Route `wl-copy` through `xclip`, which
+   reaches the clipboard over Xwayland, using a shim earlier in `PATH` than
+   `/usr/bin` (needs `xclip` and a running Xwayland):
+
+   ```bash
+   #!/bin/bash
+   # ~/.local/bin/wl-copy
+   sel=clipboard
+   type=
+   while [[ $# -gt 0 ]]; do
+   	case "$1" in
+   		-p | --primary) sel=primary ;;
+   		-t | --type) shift; type="$1" ;;
+   		--type=*) type="${1#--type=}" ;;
+   		-*) ;;
+   		*) break ;;
+   	esac
+   	shift
+   done
+   [[ -z $type || $type == text/plain* ]] &&
+   	exec xclip -selection "$sel" -i
+   exec xclip -selection "$sel" -t "$type" -i
+   ```
+
+   > [!NOTE]
+   > Seen on GNOME Shell 50.2 / mutter 50.2 / wl-clipboard 2.3.0 (CachyOS,
+   > Wayland). GNOME paste is validated working on Ubuntu 24.04 / GNOME —
+   > see [compatibility.md](compatibility.md) — so this is not GNOME-wide.
+   > Run the check above before assuming it's your problem.
+
 Want the why behind all this? See
 [configuration.md](configuration.md#text-injection-devuinput-access) for how the
 udev rule grants access, and


### PR DESCRIPTION
Adds a fourth cause to **Paste does nothing / transcription doesn't get typed
into my app**: `wl-clipboard` is installed, but `wl-copy` hangs instead of
returning.

## What I hit

Dictation worked end to end except the last hop. The log showed a clean
`gRPC transcription successful`, dictation stats kept climbing, and then
`PasteText: Request timed out` every single time. `--doctor` was all-green,
including the clipboard row, so the existing causes in that section didn't
apply.

The clipboard tool itself never returns on this session:

```
$ printf 'x' | timeout 4 /usr/bin/wl-copy; echo $?
124
$ printf 'x' | timeout 4 /usr/bin/wl-copy --foreground; echo $?
124
$ timeout 4 /usr/bin/wl-paste; echo $?
124
```

Stray `wl-copy` processes pile up behind it, including the helper's own
`wl-copy --type text/plain;charset=utf-8`. Routing `wl-copy` through `xclip`
fixed it: 4 dictations, 4 `PasteText` sent, 0 timeouts, 0 helper restarts.

## Scope, honestly

I can't claim this is GNOME-wide, and I don't think it is. `compatibility.md`
lists GNOME (Wayland) paste as validated, and `.claude/memory/issue-32-validation.md`
records a passing baseline on Ubuntu 24.04 / GNOME with text injected into
gnome-text-editor. So there is a working counter-example on GNOME.

What I have is one machine: GNOME Shell 50.2 / mutter 50.2 / wl-clipboard 2.3.0
on CachyOS, Wayland, `xclip` present, `xsel` absent, Xwayland running. The doc
text says exactly that and tells the reader to run the 4-second check before
assuming it applies to them.

**Not tested:** other GNOME versions, other distributions, machines without
`wl-clipboard`, machines with `xsel` instead of `xclip`, and whether the hang
disappears when `wl-copy` is invoked from a focused terminal rather than from a
daemon. That last one would distinguish "no data-control" from "background
process never gets focus", and it's the check I'd want before anyone treats this
as a defect rather than an environment note.

## Notes

- Docs-only change. No scripts or workflows touched, so no `shellcheck` /
  `actionlint` surface. The shim in the snippet follows the bash style guide
  (tabs, `[[ ]]`, no `set -e`) and I ran it against the flag combinations the
  helper actually passes: `-n --type text/plain;charset=utf-8`, `--type
  text/html`, and `--primary`.
- Wraps at 80 columns; slots in as cause 4 under the existing `### Fix` rather
  than adding a new symptom heading, since the existing heading already covers
  the search terms.
- Unrelated but worth saying: I hit #33 on the way here, and your suggested
  Ctrl+Meta fallback works. On GNOME, holding Super for a push-to-talk press
  opens the Overview, so I ended up on Ctrl+Alt instead. Happy to open that
  separately if it's useful.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
80% AI / 20% Human
Claude: investigated the failure, measured the hang, traced it to the clipboard
step, wrote the shim, drafted the doc text and this description.
Human: hit the bug on their machine, supplied the environment, rejected an
earlier draft that claimed the problem affected all of GNOME Wayland as
unevidenced, and redirected the contribution from a bug report to a scoped
docs entry.
