### PR TITLE
PTT observability: doctor monitor-liveness probe, leaked-interval log rate-limit, ptt-trace, desktop-entry fix

### DIFF
--- a/.claude/memory/imsai-host-notes.md
+++ b/.claude/memory/imsai-host-notes.md
@@ -1,0 +1,30 @@
+# Imsai (CachyOS / KDE Wayland desktop) — host state notes
+
+The maintainer's desktop (hostname `Imsai`), where the PTT hotplug-decay bug
+(helper#7, this repo #48) was diagnosed. Not a test VM — real daily driver.
+
+- **The installed helper binary is a local build, not the release.** AUR
+  package `wispr-flow-appimage` layout under `/opt/wispr-flow-appimage`;
+  `resources/Release/wispr-flow-linux-helper` was replaced 2026-08-05 with a
+  build of `~/dev/wispr-flow-linux-helper` branch `fix/evdev-keyboard-hotplug`
+  (the helper#8 hotplug fix). It still reports `--version` `0.1.2` — do NOT
+  assume repo-tag behaviour from the version string. The pristine release
+  asset sits beside it as `wispr-flow-linux-helper.orig` (sha256 matches the
+  v0.1.2 GitHub asset). A pacman upgrade of the package will silently restore
+  the broken release helper until a fixed helper release is pinned.
+- **`/dev/input` churn sources here:** RustDesk re-creates its uinput
+  keyboard hourly on the hour; Logitech G604 (Bluetooth mouse) exposes a
+  keyboard HID node that returns on every reconnect; Keychron K2 (USB)
+  re-enumerates on replug/reset; suspend/resume cycles. `162+86 →
+  paste_event` matches in the log can come from the G604/RustDesk, so they do
+  NOT prove the Keychron stream is alive.
+- **Log forensics:** `~/.cache/wispr-flow/launcher.log` is append-only across
+  runs and holds helper stderr (with full UTC dates — use as date anchors for
+  the time-only app lines). `main.log` rotates at 3 MiB. PTT usage dates are
+  recoverable by grepping `Handling action from keycodes: ctrl + win`.
+- **`scripts/ptt-trace.sh start` was left running** (2026-08-13) writing to
+  `~/.cache/wispr-flow/ptt-trace/` to catch any residual failure with the
+  hotplug helper. Check it before diagnosing this machine again; stop it once
+  a fixed helper release is pinned and validated.
+- User PTT chord: Ctrl+Meta (`"162+91": "ptt"` in
+  `~/.config/Wispr Flow/config.json`).

--- a/.claude/memory/imsai-host-notes.md
+++ b/.claude/memory/imsai-host-notes.md
@@ -12,12 +12,14 @@ The maintainer's desktop (hostname `Imsai`), where the PTT hotplug-decay bug
   asset sits beside it as `wispr-flow-linux-helper.orig` (sha256 matches the
   v0.1.2 GitHub asset). A pacman upgrade of the package will silently restore
   the broken release helper until a fixed helper release is pinned.
-- **`/dev/input` churn sources here:** RustDesk re-creates its uinput
-  keyboard hourly on the hour; Logitech G604 (Bluetooth mouse) exposes a
-  keyboard HID node that returns on every reconnect; Keychron K2 (USB)
-  re-enumerates on replug/reset; suspend/resume cycles. `162+86 →
-  paste_event` matches in the log can come from the G604/RustDesk, so they do
-  NOT prove the Keychron stream is alive.
+- **`/dev/input` churn sources here:** Logitech G604 (Bluetooth mouse)
+  exposes a keyboard HID node that returns on every reconnect; Keychron K2
+  (USB) re-enumerates on replug/reset; suspend/resume cycles. `162+86 →
+  paste_event` matches in the log can come from the G604, so they do NOT
+  prove the Keychron stream is alive. (RustDesk — the loudest churn source
+  during the helper#7 diagnosis, re-creating a uinput keyboard hourly on the
+  hour — was **uninstalled 2026-08-13**; `input: RustDesk UInput Keyboard`
+  journal entries before that date are it.)
 - **Log forensics:** `~/.cache/wispr-flow/launcher.log` is append-only across
   runs and holds helper stderr (with full UTC dates — use as date anchors for
   the time-only app lines). `main.log` rotates at 3 MiB. PTT usage dates are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,12 @@ when you discover something non-obvious that would save the next contributor
 - [`global-key-monitor.md`](docs/learnings/global-key-monitor.md) — push-to-talk
   and the shortcut recorder are fed by helper `KeypressEvent`s (XInput2 on X11,
   evdev `/dev/input` on Wayland); the app has no hotkey detection of its own.
+- [`evdev-hotplug-decay.md`](docs/learnings/evdev-hotplug-decay.md) —
+  enumerate-once evdev capture decays to watching nothing as `/dev/input`
+  churns (hourly uinput re-creation, Bluetooth reconnects, USB re-enumeration
+  across suspend): PTT dies mid-session with `--doctor` green. Fixed by helper
+  hotplug adoption (helper#7); doctor now probes monitor liveness via
+  `/proc/<pid>/fd`, and `scripts/ptt-trace.sh` captures failure moments.
 - [`helper-spawn-env.md`](docs/learnings/helper-spawn-env.md) — the app spawns
   the helper with a replacement env (no `process.env`), starving it of
   `WAYLAND_DISPLAY`/`DISPLAY` so injection silently falls to the no-op `stub`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+### Added
+
+- `wispr-flow --doctor` now probes push-to-talk **monitor liveness**: it
+  reports the selected capture backend and, when the helper is running,
+  compares the event nodes it holds open (`/proc/<pid>/fd`) against the
+  keyboard-capable devices currently present, naming any unwatched keyboard.
+  A helper whose capture decayed (enumerate-once ≤ v0.1.2 losing re-created
+  devices, wispr-flow-linux/helper#7) previously passed every check while
+  push-to-talk was dead. (#48)
+- `scripts/ptt-trace.sh`: opt-in durable diagnosis capture — a spam-filtered
+  `main.log` follower that survives rotation plus a timestamped
+  `udevadm monitor` input-churn trail under
+  `~/.cache/wispr-flow/ptt-trace/`. (#48)
+- `docs/learnings/evdev-hotplug-decay.md`: how enumerate-once evdev capture
+  silently kills push-to-talk on churning `/dev/input`, why every health
+  signal stayed green, and the tooling that makes it observable. (#48)
+
+### Fixed
+
+- `wispr-flow --doctor` no longer false-WARNs about a missing desktop entry
+  on AppImage/AUR installs: the check now accepts `wispr-flow.desktop`,
+  `wispr-flow-appimage.desktop`, and `ai.wisprflow.WisprFlow.desktop` across
+  the system and user application dirs. (#48)
+- The two leaked status-window interval log lines (`Window is destroyed,
+  ignoring …`) flooded `main.log` at ~6.4 lines/s (98%+ of the file), burning
+  the 3 MiB rotation window in ~2.5 h and destroying failure evidence. A new
+  bundle patch (`status-interval-log-ratelimit.sh`, marker
+  `WISPR_LINUX_LOG_RATELIMIT`) samples both sites 1-in-600 so rotation keeps
+  real history; the first tick still logs, and the original message text is
+  preserved as a prefix. (#48)
+
 ## [v1.0.3] - 2026-06-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,12 @@ when you discover something non-obvious that would save the next contributor
 - [`global-key-monitor.md`](docs/learnings/global-key-monitor.md) — push-to-talk
   and the shortcut recorder are fed by helper `KeypressEvent`s (XInput2 on X11,
   evdev `/dev/input` on Wayland); the app has no hotkey detection of its own.
+- [`evdev-hotplug-decay.md`](docs/learnings/evdev-hotplug-decay.md) —
+  enumerate-once evdev capture decays to watching nothing as `/dev/input`
+  churns (hourly uinput re-creation, Bluetooth reconnects, USB re-enumeration
+  across suspend): PTT dies mid-session with `--doctor` green. Fixed by helper
+  hotplug adoption (helper#7); doctor now probes monitor liveness via
+  `/proc/<pid>/fd`, and `scripts/ptt-trace.sh` captures failure moments.
 - [`helper-spawn-env.md`](docs/learnings/helper-spawn-env.md) — the app spawns
   the helper with a replacement env (no `process.env`), starving it of
   `WAYLAND_DISPLAY`/`DISPLAY` so injection silently falls to the no-op `stub`

--- a/docs/learnings/evdev-hotplug-decay.md
+++ b/docs/learnings/evdev-hotplug-decay.md
@@ -1,0 +1,116 @@
+[< Back to learnings](index.md)
+
+# evdev hotplug decay — push-to-talk that dies quietly, hours later
+
+Hey! This one hid for weeks in plain sight: push-to-talk (and the shortcut
+recorder — same stream, see [global-key-monitor.md](global-key-monitor.md))
+worked after every app start and then **stopped hours or days into the
+session**, with `--doctor` all-green and nothing in the logs anyone read.
+The mechanism, the churn that triggers it, how it stayed invisible, and the
+tooling that now exists so it can never hide again.
+
+**Source files:**
+
+- helper `src/capture/evdev.rs` (in the
+  [`wispr-flow-linux/helper`](https://github.com/wispr-flow-linux/helper)
+  repo) — the capture loop; the fix is
+  [helper#7](https://github.com/wispr-flow-linux/helper/issues/7) /
+  [helper#8](https://github.com/wispr-flow-linux/helper/pull/8)
+- [`scripts/doctor.sh`](../../scripts/doctor.sh) — the `Monitor liveness`
+  probe this bug motivated
+- [`scripts/ptt-trace.sh`](../../scripts/ptt-trace.sh) — durable failure-moment
+  capture
+- [`scripts/patches/status-interval-log-ratelimit.sh`](../../scripts/patches/status-interval-log-ratelimit.sh)
+  — stops the log spam that was destroying the evidence
+
+## The mechanism
+
+Helper ≤ v0.1.2 enumerated `/dev/input` **once**, at capture start. Each
+keyboard got a blocking reader thread; when a device node went away the read
+failed with `ENODEV` and the thread returned **permanently**. No inotify
+watch, no rescan, no respawn — the watched set only ever shrank. Meanwhile:
+
+- `IsReady` keepalive pings the helper **main loop**, which stays perfectly
+  healthy while capture is dead — so the app never relaunches it.
+- `CheckStaleKeys` re-opens devices per query (`EVIOCGKEY`), so stale-key
+  recovery kept answering correctly — it heals stuck *keys*, never dead
+  *readers*.
+- `--doctor` checked static prerequisites only (readability, group
+  membership, binary launches), all of which stay green forever.
+
+So every layer that could have noticed reported healthy while the actual
+event stream was gone.
+
+## /dev/input churns far more than you think
+
+The trigger isn't exotic hardware. On the machine that surfaced this:
+
+- **RustDesk** destroys and re-creates its uinput keyboard **every hour on
+  the hour** (any remote-desktop agent may do the like).
+- The USB keyboard (Keychron K2) re-enumerated on replug/reset — nine
+  `read ended: No such device (os error 19)` lines across one week of logs.
+- A **Bluetooth mouse** (Logitech G604) exposes a *keyboard* HID interface
+  (macro buttons) and gets a fresh event node on every reconnect.
+- Suspend/resume re-enumerates USB downstream devices wholesale.
+
+Multi-day app sessions are normal, so "the keyboard's node was re-created at
+least once since app start" converges on certainty. One session showed PTT
+firing for the last time ~9 h in, then dead for three more days of uptime.
+
+## Why the evidence kept vanishing
+
+Two leaked status-window intervals log `Window is destroyed, ignoring …` at
+~6.4 lines/s once the Flow Bar is torn down — 98% of `main.log`, ~1.2 MiB/h
+against a 3 MiB rotation with a single `main.old.log`. **All history older
+than ~5 h was gone** by the time anyone looked, including the failure moment.
+The helper's stderr (which *did* say `read ended: No such device`) survives
+only in `launcher.log` — 30 MB, append-only, and nobody greps it.
+
+Two field tricks that made the week-old history readable anyway:
+
+- `launcher.log` lines carry time-of-day but no date; the helper's stderr
+  lines embed full UTC timestamps. Grep those as **date anchors**, then map
+  any other line to a date by line-number interpolation.
+- The app logs `Handling action from keycodes: …` only when a chord
+  *matches*. Counting those per session dates exactly when PTT last fired —
+  and a press that matches nothing logs **nothing**, which is why user
+  reports of "it stopped" have no log signature.
+
+## The traps this sets for a diagnostician
+
+- **The deployed binary may not be the repo.** The affected machine ran a
+  *locally built* helper (with the hotplug fix) that still reported
+  `--version` `0.1.2` — identical to the broken release. Check mtimes and
+  sizes against the pinned release asset (`helper-version.txt`) before
+  reasoning from source. A `.orig` beside the binary is the tell.
+- **"Ctrl+V still triggers actions" does not prove the keyboard stream is
+  alive** — `162+86 → paste_event` matches on paste *tracking*, and those
+  events can come from another device (remote-desktop uinput, mouse macro
+  buttons) while the physical keyboard's reader is dead.
+- **A green doctor proved nothing** until it grew the liveness probe below.
+
+## The fix, and the observability that backs it
+
+- **Helper** ([helper#8](https://github.com/wispr-flow-linux/helper/pull/8)):
+  a hotplug monitor thread rescans on inotify
+  `IN_CREATE|IN_ATTRIB|IN_MOVED_TO` under `/dev/input` (`IN_ATTRIB` because
+  udev applies the `uaccess` ACL *after* node creation) with a 10 s backstop;
+  readers deregister on exit so returning devices are re-adopted. The rescan
+  must skip the helper's **own** uinput injection keyboard by `EVIOCGNAME` —
+  it is created after capture starts, so only a rescan can see it, and
+  watching it would echo every injected keystroke back as user input.
+- **Doctor**: `Monitor liveness` compares the running helper's open
+  `/proc/<pid>/fd` event nodes against the keyboard-capable devices present
+  (KEY_A+KEY_Z bits in `/proc/bus/input/devices`), and reports the selected
+  capture backend. A decayed monitor now shows up as a named unwatched
+  keyboard instead of an all-green lie.
+- **Trace**: `scripts/ptt-trace.sh start` keeps a spam-filtered, rotation-
+  proof `main.log` follower plus a timestamped `udevadm monitor` input trail,
+  so the next "it stopped working at some point" has a failure moment on
+  disk.
+- **Spam**: the two leaked-interval log sites are sampled 1-in-600 by
+  [`status-interval-log-ratelimit.sh`](../../scripts/patches/status-interval-log-ratelimit.sh)
+  so rotation keeps real history. (Upstream's actual bug — the intervals
+  should die with the window — is worth reporting to Wispr; the flagged-off
+  `tap-watchdog` feature suggests they already fight the mac flavor of "the
+  key event source died".)

--- a/docs/learnings/global-key-monitor.md
+++ b/docs/learnings/global-key-monitor.md
@@ -5,10 +5,18 @@
 Hey! Here's something I had to learn the hard way: push-to-talk and the in-app
 shortcut recorder stay dead until the helper streams key events to the app.
 That's because **Wispr Flow has no hotkey detection of its own**. Its
-renderer-side "Keyboard Service" is fed entirely by `KeypressEvent` IPC frames
-from the helper. On macOS/Windows the Swift/C# helpers supply them via OS-level
-key hooks. The Linux helper originally shipped only text injection / focus /
+"Keyboard Service" is fed entirely by `KeypressEvent` IPC frames from the
+helper. On macOS/Windows the Swift/C# helpers supply them via OS-level key
+hooks. The Linux helper originally shipped only text injection / focus /
 clipboard, so the event stream was missing and every hotkey was silently dead.
+
+(A correction to an earlier version of this page: the Keyboard Service —
+chord matching and action dispatch — lives in the **main process**
+(`.webpack/main/index.js`), not a renderer. The hub renderer only hosts the
+shortcut-recorder UI, which main feeds via the `Shortcut` IPC while
+`isRecordingKeybind` is set. This matters when you're deciding whether a
+dead window can kill PTT: it can't — only a dead event stream or main-process
+state can.)
 
 **Source files** (in the [`wispr-flow-linux/helper`](https://github.com/wispr-flow-linux/helper) repo):
 
@@ -45,7 +53,10 @@ per session, and the choice trades device-access requirements against coverage:
   raw events from the kernel input layer, which sits **below** the display server
   and behaves identically on Wayland and X11 (the read-side mirror of the
   [uinput injection](wayland-injection.md) write path). The catch is it needs
-  read access to the input devices.
+  read access to the input devices — and it must **keep watching `/dev/input`
+  for hotplug**: a start-once enumeration silently decays to watching nothing
+  as devices churn, killing PTT hours into a session. That failure and its fix
+  get their own page: [evdev-hotplug-decay.md](evdev-hotplug-decay.md).
 
 Here's the part I really liked. XInput2 raw `detail` is the X keycode, which on
 Linux is the evdev code **+ 8**. Subtract 8 and both backends feed the *same*

--- a/docs/learnings/index.md
+++ b/docs/learnings/index.md
@@ -16,6 +16,7 @@ one of these subsystems, read its page first. I wish I had.
 | [The isPackaged / launcher rename](ispackaged-rename.md) | Why an `electron`-named launcher silently breaks DB migrations ("no such table"). |
 | [Wayland injection](wayland-injection.md) | In-process `/dev/uinput` virtual keyboard + `ext-data-control` clipboard. |
 | [Global key monitor](global-key-monitor.md) | Push-to-talk lives in the helper: XInput2 (X11) / evdev (Wayland) → `KeypressEvent`, and why both PTT and the shortcut recorder were dead without it. |
+| [evdev hotplug decay](evdev-hotplug-decay.md) | Enumerate-once capture decays to watching nothing as `/dev/input` churns — PTT dies hours into a session with doctor green; the hotplug fix, the liveness probe, and the log-spam patch that stopped destroying the evidence. |
 | [Helper spawn env](helper-spawn-env.md) | The app spawns the helper with a replacement env (no `process.env`), starving it of `WAYLAND_DISPLAY`/`DISPLAY` → silent no-op `stub` injector; recording works, injection doesn't. |
 | [Platform gates](platform-gates.md) | The darwin/win32 carve-outs Linux falls through: the `.linux`-matches-no-CSS bug behind the shifted side menu, the three gate-shape rules, and how to re-audit a new Wispr version. |
 | [Patching minified JS](patching-minified-js.md) | Rules for patches that survive re-minification: `[\w$]+` for identifiers, anchor on developer strings, assert the match count, marker-based idempotency, verify against shipped bytes. |

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -277,6 +277,12 @@ step3_patch_bundle() {
     auto "Running linux-deeplink.sh on $target_bundle"
     bash "$SCRIPT_DIR/patches/linux-deeplink.sh" "$target_bundle" \
       || warn "Deep-link patch failed -- see linux-deeplink.sh output above."
+    # Sample the two leaked-interval "Window is destroyed" log lines 1-in-600.
+    # Unpatched they are ~6.4 lines/s (98% of main.log) and burn the 3 MiB
+    # rotation window in ~2.5 h, destroying failure evidence. See issue #48.
+    auto "Running status-interval-log-ratelimit.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/status-interval-log-ratelimit.sh" "$target_bundle" \
+      || warn "Log-ratelimit patch failed -- see status-interval-log-ratelimit.sh output above."
 
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -175,6 +175,140 @@ _doctor_check_input_read() {
 }
 
 #------------------------------------------------------------------------------
+# Push-to-talk liveness — is the RUNNING helper watching the keyboards that
+# exist right now? The static readability check above stays green while a
+# helper that enumerated /dev/input once (helper <= v0.1.2) decays to watching
+# nothing as devices churn (wispr-flow-linux/helper#7): each reader thread
+# dies with its device and nothing rescans. Compare the helper's open
+# event-node fds (procfs) against the keyboard-capable nodes present now.
+#
+# A "keyboard" mirrors the helper's own filter: a /proc/bus/input/devices
+# block whose KEY bitmap advertises the letter keys KEY_A(30)+KEY_Z(44) —
+# this excludes mice, power buttons and lid switches (which still get the
+# kernel kbd handler). The helper's own uinput injection device is excluded:
+# it is deliberately never watched (it would echo injected keys).
+#------------------------------------------------------------------------------
+# Args are test seams (tests/doctor.bats drives them with fixtures):
+#   $1 proc root (default /proc)   $2 input device list   $3 launcher.log
+#   $4 helper pid override (skips pgrep)
+_doctor_check_capture_liveness() {
+	local proc_root="${1:-/proc}"
+	local devices_file="${2:-/proc/bus/input/devices}"
+	local log_path="${3:-${XDG_CACHE_HOME:-$HOME/.cache}/wispr-flow/launcher.log}"
+	local pid="${4:-}"
+
+	# Selected capture backend: the helper logs one line per launch; the
+	# newest one is authoritative for the current/most recent run.
+	local backend=''
+	if [[ -r $log_path ]]; then
+		backend=$(grep -ao 'key capture: [^"'\'']*' "$log_path" 2>/dev/null \
+			| tail -n 1) || backend=''
+		backend="${backend#key capture: }"
+	fi
+	[[ -n $backend ]] && _info "Capture backend (last helper launch): $backend"
+
+	if [[ -z $pid ]]; then
+		pid=$(pgrep -f 'wispr-flow-linux-helper$' 2>/dev/null | head -n 1)
+	fi
+	if [[ -z $pid || ! -d "$proc_root/$pid/fd" ]]; then
+		_info 'Monitor liveness: helper not running' \
+			'(launch Wispr Flow, then re-run doctor to check)'
+		return
+	fi
+
+	# XInput2 (true X11) holds no event-node fds; the comparison below only
+	# applies to the evdev backend.
+	if [[ $backend == *XInput2* ]]; then
+		_pass "Monitor liveness: helper (pid $pid) uses XInput2" \
+			'(no device fds to check)'
+		return
+	fi
+
+	if [[ ! -r $devices_file ]]; then
+		_info 'Monitor liveness: cannot read the input device list'
+		return
+	fi
+
+	# Event nodes the helper currently holds open.
+	local watched=' '
+	local fd target
+	for fd in "$proc_root/$pid/fd"/*; do
+		[[ -e $fd || -L $fd ]] || continue
+		target=$(readlink "$fd" 2>/dev/null) || continue
+		if [[ $target == /dev/input/event* ]]; then
+			watched+="${target##*/} "
+		fi
+	done
+
+	# Keyboard-capable nodes present now.
+	local -a keyboards=() unwatched=()
+	local line name='' ev='' keybits='' tok
+	while IFS= read -r line || [[ -n $line ]]; do
+		case $line in
+			N:*)
+				name="${line#*Name=\"}"
+				name="${name%\"}"
+				;;
+			B:\ KEY=*)
+				keybits="${line##* }"
+				;;
+			H:*)
+				ev=''
+				for tok in ${line#*Handlers=}; do
+					[[ $tok == event[0-9]* ]] && ev="$tok"
+				done
+				;;
+			'')
+				_doctor_liveness_collect
+				name='' ev='' keybits=''
+				;;
+		esac
+	done < "$devices_file"
+	_doctor_liveness_collect
+
+	if ((${#keyboards[@]} == 0)); then
+		_info 'Monitor liveness: no keyboard-capable input devices found'
+		return
+	fi
+	if ((${#unwatched[@]} == 0)); then
+		_pass "Monitor liveness: helper (pid $pid) is watching" \
+			"${#keyboards[@]}/${#keyboards[@]} keyboard device(s)"
+		return
+	fi
+	_warn "Monitor liveness: helper (pid $pid) is NOT watching" \
+		"${#unwatched[@]} of ${#keyboards[@]} keyboard device(s):"
+	local k
+	for k in "${unwatched[@]}"; do
+		_info "  unwatched: $k"
+	done
+	_info 'Push-to-talk from those keyboards is dead until Wispr Flow is'
+	_info 'restarted. Helper <= v0.1.2 loses keyboards that re-enumerate'
+	_info '(Bluetooth reconnect, USB replug, suspend/resume); fixed by'
+	_info 'wispr-flow-linux/helper#7 hotplug adoption.'
+}
+
+# Block-end collector for _doctor_check_capture_liveness: appends the block
+# just parsed to `keyboards` (and `unwatched` when the helper does not hold
+# its node open). Reads/writes the caller's locals; bash dynamic scoping.
+_doctor_liveness_collect() {
+	[[ -n $ev && -n $keybits ]] || return 0
+	[[ $keybits =~ ^[0-9a-fA-F]{1,16}$ ]] || return 0
+	# Letter-key capability, mirroring the helper's EVIOCGBIT filter: bits
+	# KEY_A(30) and KEY_Z(44) of the last (lowest) 64-bit word of the KEY
+	# bitmap. Mice, power buttons and lid switches fail this even when they
+	# carry the kbd handler.
+	local v=$((16#$keybits))
+	(((v >> 30) & 1)) || return 0
+	(((v >> 44) & 1)) || return 0
+	# The helper's own uinput injection keyboard is never watched by design.
+	[[ $name == 'Wispr Flow Linux Helper' ]] && return 0
+	keyboards+=("$ev ($name)")
+	if [[ $watched != *" $ev "* ]]; then
+		unwatched+=("$ev ($name)")
+	fi
+}
+
+#------------------------------------------------------------------------------
 # Clipboard tools — hard requirement on Wayland (paste/selection).
 #------------------------------------------------------------------------------
 _doctor_check_clipboard() {
@@ -465,13 +599,40 @@ _doctor_check_sandbox() {
 # checks. Out-of-disk is a known Chromium failure mode (blank window / profile
 # corruption) that is otherwise invisible.
 #------------------------------------------------------------------------------
+# Args (test seam): application dirs to search; default is the system +
+# user XDG locations. Known filenames cover the deb/rpm makers
+# (wispr-flow.desktop), the AUR AppImage package (wispr-flow-appimage.desktop),
+# and the upstream app id (ai.wisprflow.WisprFlow.desktop) used by AppImage
+# desktop integration.
+# shellcheck disable=SC2120  # args are an optional test seam; prod uses the
+# default dir list, tests/doctor.bats drives it with fixture dirs.
 _doctor_check_desktop_entry() {
-	local desktop_file='/usr/share/applications/wispr-flow.desktop'
-	if [[ -f $desktop_file ]]; then
-		_pass "Desktop entry: $desktop_file"
+	local -a names=(
+		'wispr-flow.desktop'
+		'wispr-flow-appimage.desktop'
+		'ai.wisprflow.WisprFlow.desktop'
+	)
+	local -a dirs
+	if (($#)); then
+		dirs=("$@")
 	else
-		_warn 'Desktop entry: not found (expected for AppImage installs)'
+		dirs=(
+			'/usr/share/applications'
+			'/usr/local/share/applications'
+			"${XDG_DATA_HOME:-$HOME/.local/share}/applications"
+		)
 	fi
+	local d n
+	for d in "${dirs[@]}"; do
+		for n in "${names[@]}"; do
+			if [[ -f "$d/$n" ]]; then
+				_pass "Desktop entry: $d/$n"
+				return
+			fi
+		done
+	done
+	_warn 'Desktop entry: none found (expected for portable AppImage runs)'
+	_info "Looked for: ${names[*]}"
 }
 
 _doctor_check_disk_space() {
@@ -526,6 +687,7 @@ run_doctor() {
 
 	echo -e "${_bold}Push-to-Talk (input monitor)${_reset}"
 	_doctor_check_input_read
+	_doctor_check_capture_liveness
 	echo
 
 	echo -e "${_bold}Clipboard${_reset}"

--- a/scripts/patches/status-interval-log-ratelimit.sh
+++ b/scripts/patches/status-interval-log-ratelimit.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#===============================================================================
+# status-interval-log-ratelimit.sh
+#
+# Rate-limits the two leaked-interval log lines that flood main.log once the
+# status (Flow Bar) window has been torn down, in the webpack-bundled Electron
+# main process (.webpack/main/index.js).
+#
+# WHY THIS PATCH EXISTS
+# ---------------------
+# The status window uses a destroy-on-hide / rebuild-on-show lifecycle, but two
+# of its main-process intervals (monitorMove @400ms and the alpha-region
+# hit-test poll @~250ms) keep firing after the window is destroyed. Each tick
+# logs one line:
+#
+#   [info] Window is destroyed, ignoring monitorMove interval
+#   [info] Window is destroyed, ignoring interval for ignoreMouseEventsWhenNotInAlphaRegion
+#
+# Together that is ~6.4 lines/second, ~1.2 MiB/hour -- 98%+ of main.log in the
+# field. electron-log rotates at 3 MiB with a single main.old.log, so the spam
+# destroys all diagnostic history in ~5 hours and the evidence of any failure
+# moment (e.g. wispr-flow-linux/helper#7) is routinely gone by the time anyone
+# looks. Upstream's real bug is that the intervals are not cleared when the
+# window is destroyed; until that is fixed upstream, sampling the two log
+# sites 1-in-600 keeps a heartbeat of the condition (~1 line per 4 minutes
+# per site) without burning the rotation window. See issue #48.
+#
+# THE PATCH (two sites, expression-safe)
+# --------------------------------------
+# Each site has the minified shape
+#
+#   <id>().info("<literal>")
+#
+# one in statement position (`else a().info(...)`), one behind `return void`.
+# The replacement is therefore a pure expression, valid in both positions:
+#
+#   ((globalThis.WISPR_LINUX_LOG_RATELIMIT_<K> =
+#     (globalThis.WISPR_LINUX_LOG_RATELIMIT_<K>||0)+1)%600!==1 ||
+#       <id>().info("<literal> [sampled 1/600]"))
+#
+# The counter lives on globalThis (one per site), the first tick still logs
+# (so the condition remains visible), and the original developer string stays
+# a prefix of the logged message so existing greps keep matching. The marker
+# WISPR_LINUX_LOG_RATELIMIT is carried by the counter names themselves.
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+  # default to the in-repo extracted bundle
+  BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+  echo "ERROR: bundle not found: $BUNDLE" >&2
+  exit 1
+fi
+
+# --- Idempotency guard --------------------------------------------------------
+RL_MARKER="WISPR_LINUX_LOG_RATELIMIT"
+if grep -q "$RL_MARKER" "$BUNDLE"; then
+  echo "Already patched ($RL_MARKER present in $BUNDLE) - nothing to do."
+  exit 0
+fi
+
+# --- Backup -------------------------------------------------------------------
+if [[ ! -f "$BUNDLE.orig" ]]; then
+  cp -p "$BUNDLE" "$BUNDLE.orig"
+  echo "Backup written: $BUNDLE.orig"
+fi
+
+# --- Patch (anchored on the preserved developer log strings) ------------------
+python3 - "$BUNDLE" "$RL_MARKER" <<'PY'
+import re, sys, io
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+# (counter-suffix, developer log string). The strings are the stable anchors;
+# the logger identifier ([\w$]+ -- minified names may contain $) is captured
+# per site.
+SITES = [
+    ("MM", "Window is destroyed, ignoring monitorMove interval"),
+    ("ALPHA",
+     "Window is destroyed, ignoring interval for "
+     "ignoreMouseEventsWhenNotInAlphaRegion"),
+]
+
+for key, literal in SITES:
+    pat = re.compile(r'([\w$]+)\(\)\.info\("' + re.escape(literal) + r'"\)')
+    matches = pat.findall(data)
+    if len(matches) != 1:
+        sys.exit(
+            f"ERROR: expected exactly 1 '{literal[:40]}...' log site, "
+            f"found {len(matches)}. Bundle layout changed; re-audit "
+            f"(docs/learnings/patching-minified-js.md).")
+    ctr = f"globalThis.{marker}_{key}"
+
+    def repl(m, ctr=ctr, literal=literal):
+        logger = m.group(1)
+        return (f"(({ctr}=({ctr}||0)+1)%600!==1||"
+                f'{logger}().info("{literal} [sampled 1/600]"))')
+
+    data = pat.sub(repl, data, count=1)
+
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+print("Patched: both leaked-interval log sites now sample 1-in-600 (2).")
+PY
+
+# --- Verify the result --------------------------------------------------------
+if ! grep -q "$RL_MARKER" "$BUNDLE"; then
+  echo "ERROR: post-patch verification failed (marker not found)." >&2
+  echo "       Restoring backup." >&2
+  cp -p "$BUNDLE.orig" "$BUNDLE"
+  exit 1
+fi
+
+# Syntax-check: the replacement is an expression spliced into two different
+# grammatical positions; catch any edit that serializes but doesn't parse.
+if command -v node >/dev/null; then
+  if ! node --check "$BUNDLE"; then
+    echo "ERROR: node --check failed on patched bundle. Restoring backup." >&2
+    cp -p "$BUNDLE.orig" "$BUNDLE"
+    exit 1
+  fi
+  echo "node --check OK"
+fi
+echo "OK: leaked-interval log spam is rate-limited (1/600 per site) in $BUNDLE"

--- a/scripts/ptt-trace.sh
+++ b/scripts/ptt-trace.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# ptt-trace.sh -- durable capture for diagnosing input-stream failures.
+#
+# `main.log` rotates at 3 MiB and, on affected builds, is ~98% leaked-interval
+# spam, so evidence of a push-to-talk failure moment is usually destroyed
+# before anyone looks (issue #48). This tool keeps a filtered, rotation-proof
+# trail under ~/.cache/wispr-flow/ptt-trace/:
+#
+#   main-filtered.log  every main.log line except the two spam lines
+#                      (tail -F follows across rotation)
+#   udev-input.log     timestamped `udevadm monitor` input-subsystem events
+#                      (device add/remove -- correlate failures with churn)
+#
+# Usage:  ptt-trace.sh start | stop | status
+#
+# Start it, reproduce the failure (hours/days), then read the two files side
+# by side around the failure moment. Stop it when done -- the followers are
+# cheap but not free.
+#
+# Project styleguide: tabs, [[ ]], no set -e.
+
+trace_dir="${XDG_CACHE_HOME:-$HOME/.cache}/wispr-flow/ptt-trace"
+main_log="${XDG_CONFIG_HOME:-$HOME/.config}/Wispr Flow/logs/main.log"
+
+# The two leaked-interval lines that flood main.log (see
+# scripts/patches/status-interval-log-ratelimit.sh).
+spam_re='Window is destroyed, ignoring (monitorMove interval|interval for ignoreMouseEventsWhenNotInAlphaRegion)'
+
+usage() {
+	echo "usage: ${0##*/} start|stop|status" >&2
+	exit 2
+}
+
+pid_alive() {
+	local pid_file="$1" pid
+	[[ -r $pid_file ]] || return 1
+	pid=$(< "$pid_file")
+	[[ $pid =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null
+}
+
+start_follower() {
+	# tail -F survives electron-log's copy-truncate rotation.
+	(
+		tail -n 0 -F "$main_log" 2>/dev/null \
+			| grep -avE --line-buffered "$spam_re" \
+			>> "$trace_dir/main-filtered.log"
+	) &
+	echo $! > "$trace_dir/follower.pid"
+}
+
+start_udev_monitor() {
+	if ! command -v udevadm &>/dev/null; then
+		echo 'WARN: udevadm not found; skipping input-churn monitor' >&2
+		return
+	fi
+	(
+		udevadm monitor --udev --subsystem-match=input 2>/dev/null \
+			| while IFS= read -r line; do
+				printf '%(%F %T)T %s\n' -1 "$line"
+			done >> "$trace_dir/udev-input.log"
+	) &
+	echo $! > "$trace_dir/udev.pid"
+}
+
+cmd_start() {
+	mkdir -p "$trace_dir"
+	if pid_alive "$trace_dir/follower.pid"; then
+		echo "already running (see: ${0##*/} status)"
+		return 0
+	fi
+	printf '%(%F %T)T === ptt-trace start ===\n' -1 \
+		>> "$trace_dir/main-filtered.log"
+	start_follower
+	start_udev_monitor
+	echo "tracing into $trace_dir"
+	echo '  main-filtered.log  (spam-free main.log follower)'
+	[[ -f $trace_dir/udev.pid ]] \
+		&& echo '  udev-input.log     (input device add/remove)'
+}
+
+cmd_stop() {
+	local f stopped=0
+	for f in "$trace_dir/follower.pid" "$trace_dir/udev.pid"; do
+		if pid_alive "$f"; then
+			# Kill the subshell's process group children too.
+			pkill -P "$(< "$f")" 2>/dev/null
+			kill "$(< "$f")" 2>/dev/null
+			stopped=$((stopped + 1))
+		fi
+		rm -f "$f"
+	done
+	((stopped > 0)) && echo 'stopped' || echo 'not running'
+}
+
+cmd_status() {
+	local running=0
+	if pid_alive "$trace_dir/follower.pid"; then
+		echo "main.log follower: running (pid $(< "$trace_dir/follower.pid"))"
+		running=1
+	else
+		echo 'main.log follower: not running'
+	fi
+	if pid_alive "$trace_dir/udev.pid"; then
+		echo "udev monitor:      running (pid $(< "$trace_dir/udev.pid"))"
+		running=1
+	else
+		echo 'udev monitor:      not running'
+	fi
+	if [[ -d $trace_dir ]]; then
+		du -sh "$trace_dir" 2>/dev/null
+	fi
+	((running == 1))
+}
+
+case "${1:-}" in
+	start)  cmd_start ;;
+	stop)   cmd_stop ;;
+	status) cmd_status ;;
+	*)      usage ;;
+esac

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -11,6 +11,8 @@
 #     * mac-gates.sh           -> gates the macOS Applications-folder guard
 #     * linux-window-frame.sh  -> frameless hub/settings window on Linux
 #     * linux-deeplink.sh      -> cold-start wispr-flow: argv parse on Linux
+#     * status-interval-log-ratelimit.sh -> samples the leaked-interval
+#       "Window is destroyed" spam 1-in-600 so rotation keeps real history
 #   renderer bundles:
 #     * linux-renderer-chrome.sh -> remaps the <html> platform class linux->win32
 #     * linux-renderer-treat-as-windows.sh -> widens each renderer's isWindows
@@ -48,6 +50,7 @@ MARKERS=(
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
+  "log-ratelimit: leaked-interval spam sampled 1/600|F|WISPR_LINUX_LOG_RATELIMIT"
 )
 
 missing=0

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -345,3 +345,144 @@ command() {
 	run run_doctor "$TEST_TMP/does-not-exist"
 	[[ $status -ne 0 ]]
 }
+
+# =============================================================================
+# _doctor_check_desktop_entry (dir arguments let us drive it with fixtures)
+# =============================================================================
+
+@test "_doctor_check_desktop_entry: passes on the deb/rpm filename" {
+	local dir="$TEST_TMP/apps"
+	mkdir -p "$dir"
+	: >"$dir/wispr-flow.desktop"
+	run _doctor_check_desktop_entry "$dir"
+	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"wispr-flow.desktop"* ]]
+}
+
+@test "_doctor_check_desktop_entry: passes on the AUR AppImage filename" {
+	local dir="$TEST_TMP/apps"
+	mkdir -p "$dir"
+	: >"$dir/wispr-flow-appimage.desktop"
+	run _doctor_check_desktop_entry "$dir"
+	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"wispr-flow-appimage.desktop"* ]]
+}
+
+@test "_doctor_check_desktop_entry: passes on the upstream app-id filename" {
+	local dir="$TEST_TMP/apps"
+	mkdir -p "$dir"
+	: >"$dir/ai.wisprflow.WisprFlow.desktop"
+	run _doctor_check_desktop_entry "$dir"
+	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"ai.wisprflow.WisprFlow.desktop"* ]]
+}
+
+@test "_doctor_check_desktop_entry: warns (not fails) when nothing found" {
+	local dir="$TEST_TMP/apps-empty"
+	mkdir -p "$dir"
+	_doctor_failures=0
+	run _doctor_check_desktop_entry "$dir"
+	[[ $output == *"[WARN]"* ]]
+	_doctor_check_desktop_entry "$dir" >/dev/null
+	[[ $_doctor_failures -eq 0 ]]
+}
+
+# =============================================================================
+# _doctor_check_capture_liveness (proc root / devices file / log / pid seams)
+# =============================================================================
+
+# A devices-file block for a keyboard advertising KEY_A..KEY_Z (the last KEY
+# word 0xfffffffffffffffe has bits 30 and 44 set) plus a mouse that must be
+# ignored (no letter keys in its KEY bitmap).
+_liveness_fixture_devices() {
+	cat > "$1" <<'DEV'
+I: Bus=0003 Vendor=05ac Product=024f Version=0111
+N: Name="Fixture Keyboard"
+H: Handlers=sysrq kbd leds event4
+B: KEY=1000000000007 ff9f207ac14057ff febeffdfffefffff fffffffffffffffe
+
+I: Bus=0003 Vendor=046d Product=b024 Version=0111
+N: Name="Fixture Mouse"
+H: Handlers=mouse0 event7
+B: KEY=1f0000 0 0 0
+
+I: Bus=0000 Vendor=0000 Product=0000 Version=0000
+N: Name="Wispr Flow Linux Helper"
+H: Handlers=sysrq kbd event9
+B: KEY=1000000000007 ff9f207ac14057ff febeffdfffefffff fffffffffffffffe
+DEV
+}
+
+# Fake proc tree: $1=proc root  $2=pid  $3...=event nodes held open
+_liveness_fixture_proc() {
+	local root="$1" pid="$2" ev
+	shift 2
+	mkdir -p "$root/$pid/fd"
+	local i=10
+	for ev in "$@"; do
+		ln -s "/dev/input/$ev" "$root/$pid/fd/$i"
+		i=$((i + 1))
+	done
+}
+
+@test "capture_liveness: passes when the helper holds every keyboard open" {
+	local devs="$TEST_TMP/devices" log="$TEST_TMP/launcher.log"
+	_liveness_fixture_devices "$devs"
+	printf 'key capture: evdev (/dev/input)\n' > "$log"
+	_liveness_fixture_proc "$TEST_TMP/proc" 4242 event4
+	_doctor_failures=0
+	run _doctor_check_capture_liveness "$TEST_TMP/proc" "$devs" "$log" 4242
+	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"1/1 keyboard"* ]]
+	[[ $output == *"evdev"* ]]
+}
+
+@test "capture_liveness: warns and names the unwatched keyboard" {
+	local devs="$TEST_TMP/devices" log="$TEST_TMP/launcher.log"
+	_liveness_fixture_devices "$devs"
+	printf 'key capture: evdev (/dev/input)\n' > "$log"
+	# Helper runs but holds no event node open (decayed monitor).
+	_liveness_fixture_proc "$TEST_TMP/proc" 4242
+	_doctor_failures=0
+	run _doctor_check_capture_liveness "$TEST_TMP/proc" "$devs" "$log" 4242
+	[[ $output == *"[WARN]"* ]]
+	[[ $output == *"Fixture Keyboard"* ]]
+	[[ $output == *"restarted"* ]]
+	_doctor_check_capture_liveness "$TEST_TMP/proc" "$devs" "$log" 4242 \
+		>/dev/null
+	[[ $_doctor_failures -eq 0 ]]
+}
+
+@test "capture_liveness: ignores mice and the helper's own uinput device" {
+	local devs="$TEST_TMP/devices" log="$TEST_TMP/launcher.log"
+	_liveness_fixture_devices "$devs"
+	printf 'key capture: evdev (/dev/input)\n' > "$log"
+	# Only the real keyboard is held open; the mouse (event7) and the
+	# helper's own device (event9) must not be counted as unwatched.
+	_liveness_fixture_proc "$TEST_TMP/proc" 4242 event4
+	run _doctor_check_capture_liveness "$TEST_TMP/proc" "$devs" "$log" 4242
+	[[ $output == *"[PASS]"* ]]
+	[[ $output != *"Fixture Mouse"* ]]
+	[[ $output != *"Wispr Flow Linux Helper"* ]]
+}
+
+@test "capture_liveness: XInput2 backend passes without fd comparison" {
+	local devs="$TEST_TMP/devices" log="$TEST_TMP/launcher.log"
+	_liveness_fixture_devices "$devs"
+	printf 'key capture: XInput2 (X11, no device access needed)\n' > "$log"
+	_liveness_fixture_proc "$TEST_TMP/proc" 4242
+	run _doctor_check_capture_liveness "$TEST_TMP/proc" "$devs" "$log" 4242
+	[[ $output == *"[PASS]"* ]]
+	[[ $output == *"XInput2"* ]]
+}
+
+@test "capture_liveness: helper not running is informational only" {
+	local devs="$TEST_TMP/devices" log="$TEST_TMP/launcher.log"
+	_liveness_fixture_devices "$devs"
+	printf 'key capture: evdev (/dev/input)\n' > "$log"
+	_doctor_failures=0
+	run _doctor_check_capture_liveness "$TEST_TMP/proc-none" "$devs" "$log" 99
+	[[ $output == *"helper not running"* ]]
+	[[ $output != *"[FAIL]"* ]]
+	[[ $_doctor_failures -eq 0 ]]
+}

--- a/tests/linux-patches.bats
+++ b/tests/linux-patches.bats
@@ -202,3 +202,45 @@ JS
 	[[ "$status" -ne 0 ]]
 	! grep -q 'WISPR_LINUX_DEEPLINK' "$FIX"
 }
+
+# =============================================================================
+# status-interval-log-ratelimit.sh
+# =============================================================================
+
+# Both real sites: statement position (else-branch) and expression position
+# (return void). The fixture mirrors the shipped minified shapes.
+_ratelimit_fixture() {
+	cat > "$FIX" <<'JS'
+const ee=async()=>{if(w&&!w.isDestroyed()){try{mv()}finally{rel()}}else a().info("Window is destroyed, ignoring monitorMove interval")},te=()=>setInterval(ee,400);
+const poll=()=>{if(!w||w.isDestroyed())return void a().info("Window is destroyed, ignoring interval for ignoreMouseEventsWhenNotInAlphaRegion");if(x)y()};
+JS
+}
+
+@test "ratelimit: wraps both sites, keeps original strings as prefixes" {
+	_ratelimit_fixture
+	run bash "$PATCH_DIR/status-interval-log-ratelimit.sh" "$FIX"
+	[[ "$status" -eq 0 ]]
+	grep -q 'WISPR_LINUX_LOG_RATELIMIT_MM' "$FIX"
+	grep -q 'WISPR_LINUX_LOG_RATELIMIT_ALPHA' "$FIX"
+	grep -q 'Window is destroyed, ignoring monitorMove interval \[sampled 1/600\]' "$FIX"
+	grep -q 'ignoreMouseEventsWhenNotInAlphaRegion \[sampled 1/600\]' "$FIX"
+	node_check "$FIX"
+}
+
+@test "ratelimit: idempotent (second run is a byte-identical no-op)" {
+	_ratelimit_fixture
+	run bash "$PATCH_DIR/status-interval-log-ratelimit.sh" "$FIX"
+	[[ "$status" -eq 0 ]]
+	assert_idempotent "$PATCH_DIR/status-interval-log-ratelimit.sh" "$FIX"
+}
+
+@test "ratelimit: bails non-zero when an anchor is missing" {
+	cat > "$FIX" <<'JS'
+const unrelated = () => a().info("some other log line");
+JS
+	run bash "$PATCH_DIR/status-interval-log-ratelimit.sh" "$FIX"
+	[[ "$status" -ne 0 ]]
+	[[ "$output" == *"expected exactly 1"* ]]
+	# The failed run must not leave a half-patched file behind.
+	! grep -q 'WISPR_LINUX_LOG_RATELIMIT' "$FIX"
+}

--- a/tests/verify-patches.bats
+++ b/tests/verify-patches.bats
@@ -37,6 +37,7 @@ declare -gA MARKER_SAMPLES=(
 	[windowframe]='"win32"===process.platform||"linux"===process.platform/*WISPR_LINUX_FRAMELESS*/&&Object.assign(t,{titleBarStyle:"hidden"});'
 	[treataswindows]='const x=((y?.platform?.isWindows??!1)||"linux"===y?.platform?.os)/*WISPR_LINUX_RENDERER_ISWIN*/;'
 	[deeplink]='if(f.H8||"linux"===process.platform){/*WISPR_LINUX_DEEPLINK*/const e=process.argv.find(x=>x.startsWith("wispr-flow:"));}'
+	[logratelimit]='((globalThis.WISPR_LINUX_LOG_RATELIMIT_MM=(globalThis.WISPR_LINUX_LOG_RATELIMIT_MM||0)+1)%600!==1||a().info("Window is destroyed, ignoring monitorMove interval [sampled 1/600]"))'
 )
 
 # Write a fixture app.asar-like file containing every marker, except the one
@@ -149,6 +150,14 @@ write_fixture() {
 @test "verify: exits 1 when the deeplink marker is missing" {
 	local fixture
 	fixture="$(write_fixture deeplink)"
+	run "$VERIFY_SH" "$fixture"
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *'MISSING'* ]]
+}
+
+@test "verify: exits 1 when the log-ratelimit marker is missing" {
+	local fixture
+	fixture="$(write_fixture logratelimit)"
 	run "$VERIFY_SH" "$fixture"
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *'MISSING'* ]]


### PR DESCRIPTION
Fixes #48. Companion to wispr-flow-linux/helper#8 (the root-cause fix).

## Diagnosis this PR is built on

Push-to-talk "works, then stops after some period of running; restart fixes it" on KDE Wayland was traced to the helper's enumerate-once evdev capture (wispr-flow-linux/helper#7): reader threads die permanently with their device node, and `/dev/input` churns constantly in the field (hourly RustDesk uinput re-creation, Bluetooth HID reconnects, USB re-enumeration across suspend). Every health signal stayed green while capture decayed — the keepalive pings the helper main loop, `CheckStaleKeys` re-opens devices per query, and `--doctor` checked only static prerequisites. The evidence of each failure moment was destroyed within ~5 h by two leaked-interval log lines eating 98% of the 3 MiB `main.log` rotation.

The other two candidate mechanisms were falsified: the helper picks the correct evdev backend on Wayland every launch (`helper-env.sh` marker verified in shipped bytes, `key capture: evdev` in every session), and window destruction cannot kill detection — chord matching lives in the **main process** (the learnings docs said "renderer-side"; corrected here), the hub hides on close, and the status window's destroy-on-hide has a rebuild-on-show self-heal.

## What this PR adds (this repo's side: detection + diagnosability)

- **`--doctor` Monitor liveness probe**: reports the selected capture backend and compares the running helper's open `/proc/<pid>/fd` event nodes against the keyboard-capable devices present (KEY_A+KEY_Z capability bits, mirroring the helper's filter; the helper's own uinput injection device excluded). A decayed monitor now surfaces as a named unwatched keyboard instead of an all-green lie.
- **Desktop-entry check** accepts `wispr-flow.desktop`, `wispr-flow-appimage.desktop`, and `ai.wisprflow.WisprFlow.desktop` across system/user application dirs — ends the permanent false WARN on AppImage/AUR installs.
- **`status-interval-log-ratelimit.sh`** bundle patch: samples the two `Window is destroyed, ignoring …` sites 1-in-600 (marker `WISPR_LINUX_LOG_RATELIMIT`, count-asserted, idempotent, `node --check`'d, verified against shipped 1.6.7 bytes, registered in `verify-patches.sh` + `build-linux.sh`). Rotation keeps real history again; upstream's actual interval leak is worth reporting to Wispr separately.
- **`scripts/ptt-trace.sh`**: opt-in rotation-proof filtered `main.log` follower + timestamped `udevadm monitor` input trail for catching the next failure moment in the act.
- **Docs**: new `docs/learnings/evdev-hotplug-decay.md`; `global-key-monitor.md` corrected (Keyboard Service is main-process); host-state notes in `.claude/memory/`.

## Validation

- bats: 100/100 across `doctor.bats` (10 new), `linux-patches.bats` (3 new), `verify-patches.bats` (1 new + fixture), `launcher-common.bats`.
- shellcheck clean on all touched scripts.
- Live on the affected machine: liveness probe reports `watching 6/6 keyboard device(s)` with the hotplug helper build; a virtual-keyboard Ctrl+Meta chord fired PTT end-to-end.

## Not in this PR

`helper-version.txt` stays at `v0.1.2`: the hotplug fix must first merge and release in the helper repo (wispr-flow-linux/helper#8 asks for a v0.1.3). Bumping the pin is the follow-up once that release exists.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: diagnosis, doctor liveness probe, log-ratelimit patch, ptt-trace, tests, docs
Human: prior in-field hotplug helper build that informed the diagnosis; review
