### PR TITLE
fix(linux): take the single-instance lock before any bundle init (SIGABRT on second launch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Flow app version is tracked separately by the `+wispr{X.Y.Z}` suffix.
 
 ## [Unreleased]
 
+### Fixed
+
+- Launching a second instance while the app was running crashed with
+  `SIGABRT` (coredump stack: `V8 FATAL:
+  Error::ThrowAsJavaScriptException napi_throw`) — 9 coredumps over two weeks,
+  including a 4-crashes-in-6-seconds loop. The vendor main bundle only calls
+  `app.requestSingleInstanceLock()` at the end of its ~8.3 MB bundle, so a
+  second launch fully initialized (native `.node` modules, better-sqlite3,
+  helper IPC) before quitting, and teardown of that half-initialized state
+  aborted. A new `linux-early-singleton.sh` patch inserts a guard before the
+  webpack IIFE that takes the lock first and `process.exit(0)`s immediately
+  when it is not acquired — the abort class is unreachable, and the running
+  primary still focuses its hub window via the `second-instance` event
+  (argv handshake completes during the failed lock request). `--quit-app`
+  and `wispr-flow:` deep links keep working through the primary's existing
+  handler.
+
 ## [v1.0.3] - 2026-06-11
 
 ### Fixed

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -277,6 +277,19 @@ step3_patch_bundle() {
     auto "Running linux-deeplink.sh on $target_bundle"
     bash "$SCRIPT_DIR/patches/linux-deeplink.sh" "$target_bundle" \
       || warn "Deep-link patch failed -- see linux-deeplink.sh output above."
+    # Take the Electron single-instance lock at the very top of the bundle,
+    # before ANY init runs. The vendor only requests the lock at the end of
+    # its ~8.3 MB bundle, so a second launch fully initializes (native .node
+    # modules, better-sqlite3, helper IPC) and then quits -- teardown of that
+    # half-initialized native state aborts with V8 FATAL napi_throw (9
+    # SIGABRT coredumps observed 2026-08-18/26, incl. a 4-in-6s crash loop).
+    # With the early guard the second instance exits before executing another
+    # byte; the primary still gets `second-instance` (argv handshake happens
+    # during the failed lock request) and focuses its hub window. See
+    # patches/linux-early-singleton.sh.
+    auto "Running linux-early-singleton.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-early-singleton.sh" "$target_bundle" \
+      || warn "Early-singleton patch failed -- see linux-early-singleton.sh output above."
 
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"

--- a/scripts/patches/linux-early-singleton.sh
+++ b/scripts/patches/linux-early-singleton.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#===============================================================================
+# patch-linux-early-singleton.sh -- take the Electron single-instance lock at
+# the very top of the Wispr Flow main bundle, before any other code runs.
+#
+# Bug it fixes (observed 2026-08-18 / 2026-08-26, 9 coredumps):
+#   The vendor bundle calls app.requestSingleInstanceLock() only at the END of
+#   its ~8.3 MB main bundle, after the full app has initialized (native
+#   .node modules, better-sqlite3, helper IPC, window scaffolding). A second
+#   launch therefore runs that entire init and then quits -- and teardown of
+#   half-initialized native state aborts with
+#       V8 FATAL: Error::ThrowAsJavaScriptException napi_throw -> SIGABRT
+#   killing the second instance (and in the worst case destabilizing the
+#   session with a crash loop: 4 SIGABRTs in 6s on 2026-08-26 12:23).
+#
+# Fix:
+#   Prepend a guard before the webpack IIFE: if the lock is not acquired,
+#   app.quit() + process.exit(0) immediately. Nothing else in the bundle ever
+#   executes -- the abort class becomes unreachable. The already-running
+#   primary still receives the `second-instance` event (delivered during the
+#   failed lock handshake, before process.exit) and focuses its hub window,
+#   which is exactly the UX a user expects from clicking the icon again.
+#   `--quit-app` and wispr-flow: deep-link argv keep working: the primary's
+#   existing second-instance handler reads them from the argv it receives.
+#
+# Lock-path note: the guard relies on Electron's default userData-derived
+# singleton path, the same mechanism the vendor's late call uses (neither
+# setPath('userData') before locking), so both resolve to the identical
+# ~/.config/Wispr Flow/SingletonLock. Do not add a setPath here -- that could
+# fork the lock namespace.
+#
+# Surgical edit (idempotent, keeps a .earlysingleton.orig backup, verified):
+#   /*! For license ... */            <- vendor license comment stays first
+#   /*WISPR_LINUX_EARLY_SINGLETON_V1*/try{...process.exit(0)}catch{}
+#   !function(){...}                  <- webpack IIFE, untouched
+#
+# Usage: patch-linux-early-singleton.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" || ! -f "$BUNDLE" ]]; then
+  echo "usage: $0 <.webpack/main/index.js>" >&2
+  exit 2
+fi
+
+python3 - "$BUNDLE" <<'PY'
+import sys, shutil
+
+path = sys.argv[1]
+src = open(path, 'r', encoding='utf-8', errors='surrogateescape').read()
+
+MARKER = 'WISPR_LINUX_EARLY_SINGLETON_V1'
+GUARD = (
+    '/*' + MARKER + '*/'
+    'try{var __wisprApp=require("electron").app;'
+    'if(__wisprApp&&!__wisprApp.requestSingleInstanceLock()){'
+    '__wisprApp.quit(),process.exit(0)}}catch(__wisprErr){}'
+)
+
+if MARKER in src:
+    print("Already patched (marker %s present). Nothing to do." % MARKER)
+    sys.exit(0)
+
+# Keep the vendor license banner as line 1; insert the guard right after it
+# (or at byte 0 when there is no banner). The banner shape is stable across
+# webpack builds: /*! For license information please see ... */
+first_line, _nl, rest = src.partition('\n')
+if first_line.startswith('/*!') and first_line.rstrip().endswith('*/'):
+    patched = first_line + '\n' + GUARD + '\n' + rest
+else:
+    patched = GUARD + '\n' + src
+
+shutil.copyfile(path, path + ".earlysingleton.orig")
+print("Backup written:", path + ".earlysingleton.orig")
+
+# Verify: marker present exactly once, and located before the webpack IIFE
+# start (`!function` at this build's head) so nothing precedes the guard
+# except the license comment.
+if patched.count(MARKER) != 1:
+    print("ERROR: verification failed -- marker count != 1.", file=sys.stderr)
+    sys.exit(1)
+head = patched[:patched.index(MARKER)]
+if 'function' in head.replace('For license information', ''):
+    print("ERROR: verification failed -- code precedes the guard.",
+          file=sys.stderr)
+    sys.exit(1)
+
+open(path, 'w', encoding='utf-8', errors='surrogateescape').write(patched)
+print("OK: early single-instance guard inserted (%d bytes)." % len(GUARD))
+PY
+
+# Syntax-check the patched bundle.
+if command -v node >/dev/null; then
+  node --check "$BUNDLE" && echo "node --check OK"
+fi
+echo "Done: a second instance now exits before any initialization runs."

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -48,6 +48,7 @@ MARKERS=(
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
+  "early-singleton: second instance exits before init|F|WISPR_LINUX_EARLY_SINGLETON_V1"
 )
 
 missing=0

--- a/tests/linux-patches.bats
+++ b/tests/linux-patches.bats
@@ -1,13 +1,14 @@
 #!/usr/bin/env bats
 #
 # linux-patches.bats
-# Unit tests for the four renderer/main bundle patches added for the Linux port:
+# Unit tests for the renderer/main bundle patches added for the Linux port:
 #   * linux-renderer-chrome.sh           -> remaps the <html> platform class linux->win32
 #   * linux-window-frame.sh              -> frameless hub/settings window on Linux
 #   * linux-renderer-treat-as-windows.sh -> widens each renderer's isWindows bind
 #                                           (bridge stays honest; no preload touched)
 #   * linux-deeplink.sh                  -> cold-start wispr-flow: argv parse on Linux
-#
+#   * linux-early-singleton.sh           -> take the single-instance lock before init
+
 # The real bundle is the proprietary, gitignored app -- not available in CI -- so
 # each test drives a hermetic minified-JS FIXTURE carrying the exact anchor the
 # patch keys on. Every patch is asserted to: apply (marker + transformation),
@@ -201,4 +202,49 @@ JS
 	run bash "$PATCH_DIR/linux-deeplink.sh" "$FIX"
 	[[ "$status" -ne 0 ]]
 	! grep -q 'WISPR_LINUX_DEEPLINK' "$FIX"
+}
+
+# =============================================================================
+# linux-early-singleton.sh
+# =============================================================================
+
+@test "early-singleton: guard lands after the license banner, before the IIFE" {
+	cat > "$FIX" <<'JS'
+/*! For license information please see index.js.LICENSE.txt */
+!function(){console.log("app init")}()
+JS
+	run bash "$PATCH_DIR/linux-early-singleton.sh" "$FIX"
+	[[ "$status" -eq 0 ]]
+	# License banner stays line 1.
+	[[ "$(head -1 "$FIX")" == '/*! For license information please see index.js.LICENSE.txt */' ]]
+	# Guard is line 2 and keys on the real Electron API, not a minified name.
+	grep -qF 'WISPR_LINUX_EARLY_SINGLETON_V1' "$FIX"
+	grep -qF 'require("electron").app' "$FIX"
+	grep -qF 'requestSingleInstanceLock' "$FIX"
+	grep -qF 'process.exit(0)' "$FIX"
+	# Nothing but the banner precedes the guard.
+	[[ "$(grep -nF 'WISPR_LINUX_EARLY_SINGLETON_V1' "$FIX" | cut -d: -f1)" -eq 2 ]]
+	node_check "$FIX"
+}
+
+@test "early-singleton: guard at byte 0 when there is no banner" {
+	printf '!function(){console.log("app init")}()' > "$FIX"
+	run bash "$PATCH_DIR/linux-early-singleton.sh" "$FIX"
+	[[ "$status" -eq 0 ]]
+	[[ "$(grep -nF 'WISPR_LINUX_EARLY_SINGLETON_V1' "$FIX" | cut -d: -f1)" -eq 1 ]]
+	node_check "$FIX"
+}
+
+@test "early-singleton: idempotent on second run" {
+	printf '!function(){console.log("app init")}()' > "$FIX"
+	bash "$PATCH_DIR/linux-early-singleton.sh" "$FIX"
+	assert_idempotent "$PATCH_DIR/linux-early-singleton.sh" "$FIX"
+}
+
+@test "early-singleton: keeps a backup of the pre-patch bundle" {
+	printf '!function(){console.log("app init")}()' > "$FIX"
+	run bash "$PATCH_DIR/linux-early-singleton.sh" "$FIX"
+	[[ "$status" -eq 0 ]]
+	[[ -f "$FIX.earlysingleton.orig" ]]
+	cmp -s "$FIX.earlysingleton.orig" <(printf '!function(){console.log("app init")}()')
 }

--- a/tests/verify-patches.bats
+++ b/tests/verify-patches.bats
@@ -6,7 +6,7 @@
 # (the .asar stores the JS bundle as concatenated plaintext, so a byte-grep
 # finds the markers without unpacking).
 #
-# verify-patches.sh greps a fixed set of markers (8 fixed strings + 1 Perl
+# verify-patches.sh greps a fixed set of markers (9 fixed strings + 1 Perl
 # regex). We build a tiny fixture carrying those exact marker strings (PASS)
 # and per-marker fixtures that omit one (FAIL).
 #
@@ -37,6 +37,7 @@ declare -gA MARKER_SAMPLES=(
 	[windowframe]='"win32"===process.platform||"linux"===process.platform/*WISPR_LINUX_FRAMELESS*/&&Object.assign(t,{titleBarStyle:"hidden"});'
 	[treataswindows]='const x=((y?.platform?.isWindows??!1)||"linux"===y?.platform?.os)/*WISPR_LINUX_RENDERER_ISWIN*/;'
 	[deeplink]='if(f.H8||"linux"===process.platform){/*WISPR_LINUX_DEEPLINK*/const e=process.argv.find(x=>x.startsWith("wispr-flow:"));}'
+	[earlysingleton]='/*WISPR_LINUX_EARLY_SINGLETON_V1*/try{var __wisprApp=require("electron").app;if(__wisprApp&&!__wisprApp.requestSingleInstanceLock()){__wisprApp.quit(),process.exit(0)}}catch(__wisprErr){}'
 )
 
 # Write a fixture app.asar-like file containing every marker, except the one
@@ -149,6 +150,14 @@ write_fixture() {
 @test "verify: exits 1 when the deeplink marker is missing" {
 	local fixture
 	fixture="$(write_fixture deeplink)"
+	run "$VERIFY_SH" "$fixture"
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *'MISSING'* ]]
+}
+
+@test "verify: exits 1 when the early-singleton marker is missing" {
+	local fixture
+	fixture="$(write_fixture earlysingleton)"
 	run "$VERIFY_SH" "$fixture"
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *'MISSING'* ]]


### PR DESCRIPTION
## Problem

Launching a second instance while the app is running crashes with `SIGABRT`.
`coredumpctl` stack signature on every crash:

```
V8 FATAL: Error::ThrowAsJavaScriptException napi_throw
```

Observed in the wild on an Arch/AppImage install (1.0.3+wispr1.6.7): **9
coredumps over two weeks**, including a 4-crashes-in-6-seconds loop
(2026-08-26 12:23:25→31) where each relaunch died before showing a window.

## Root cause

The vendor main bundle calls `app.requestSingleInstanceLock()` only at the
**end** of its ~8.3 MB bundle (right before `setAsDefaultProtocolClient` /
the `second-instance` handler registration). A second launch therefore runs
the *entire* app init first — native `.node` modules, better-sqlite3, helper
IPC, window scaffolding — and only then discovers it should quit. Teardown of
that half-initialized native state surfaces an exception through a napi
callback with no JS frame to catch it → V8 fatal → `SIGABRT`.

## Fix

New `scripts/patches/linux-early-singleton.sh` (wired into the build-linux
patch sequence + verify-patches marker net): insert a guard **before the
webpack IIFE** —

```js
try{var __wisprApp=require("electron").app;
if(__wisprApp&&!__wisprApp.requestSingleInstanceLock()){
__wisprApp.quit(),process.exit(0)}}catch(__wisprErr){}
```

— so a second instance exits before executing another byte. The abort class
becomes unreachable.

What is preserved:

- The running primary still receives the `second-instance` event — the argv
  handshake completes during the failed lock request — and focuses its hub
  window. That is the correct icon-click UX (previously: crash).
- `--quit-app` and `wispr-flow:` deep links keep working: the primary's
  existing handler reads them from the argv it receives.
- Lock-path parity: the guard relies on Electron's default userData-derived
  singleton path, the same mechanism the vendor's late call uses (neither
  calls `setPath` first), so both resolve to the identical
  `~/.config/Wispr Flow/SingletonLock`. The patch deliberately does NOT set
  a path — that would fork the lock namespace.

Patch-script conventions match its siblings (mac-gates.sh et al.): idempotent
marker, `.earlysingleton.orig` backup, `node --check`, fails loudly on a
layout surprise, keeps the vendor license banner as line 1.

## Tests

- `tests/linux-patches.bats`: 4 new hermetic tests (guard lands after the
  banner / before the IIFE, byte-0 insertion without a banner, idempotency,
  backup kept).
- `tests/verify-patches.bats`: fixture + dedicated negative test for the new
  `WISPR_LINUX_EARLY_SINGLETON_V1` marker (9 fixed strings + 1 Perl regex
  now).
- Full suite: **31/31 ok**.

## Live verification (Arch x86_64, AppImage 1.0.3+wispr1.6.7, Wayland)

| Scenario | Before | After |
|---|---|---|
| Second launch while running | SIGABRT coredump | exit 0 in 0.24 s, hub window focused |
| `--quit-app` via second instance | crash-prone | clean primary shutdown in 0.3 s |
| `kill -9` + stale `SingletonLock` | crash loop (the 12:23 storm) | launcher cleans lock, clean relaunch |

Found and fixed by @jcartu (voidwalker).