### PR TITLE
Fix unpressable Linux shortcuts (#33, #46), restore helper env injection, and unbreak the installer fetch (1.6.774)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,13 +35,14 @@ original_home=''
 project_root=''
 work_dir=''
 installer_exe_path=''
+resolved_installer_sha256=''
 final_output_path=''
 
 #--- package metadata (constants) ----------------------------------------------
 readonly PACKAGE_NAME='wispr-flow'
 readonly WM_CLASS='Wispr Flow'
 export WM_CLASS
-readonly APP_VERSION='1.6.7'
+readonly APP_VERSION='1.6.774'
 readonly ELECTRON_VERSION='42.3.0'
 readonly ELECTRON_MAJOR='42'
 # Exported so scripts/build-linux.sh stages the versions the orchestrator

--- a/docs/learnings/platform-gates.md
+++ b/docs/learnings/platform-gates.md
@@ -152,6 +152,7 @@ backup, `node --check`s the result, and is idempotent (re-run = byte-identical).
 | Chrome window fell to default framed + visible menu bar → make it frameless like win32 (1.5.695: the meeting_recorder window; the Hub/scratchpad windows now self-frame Linux via a two-way else branch) | [`linux-window-frame.sh`](../../scripts/patches/linux-window-frame.sh) | `WISPR_LINUX_FRAMELESS` |
 | Fresh installs seeded macOS `fn`/⌘ shortcut defaults + skipped the onboarding Permissions step → widen each renderer's `isWindows` **bind** to also be true on linux (bridge stays honest) | [`linux-renderer-treat-as-windows.sh`](../../scripts/patches/linux-renderer-treat-as-windows.sh) | `WISPR_LINUX_RENDERER_ISWIN` |
 | Cold-start `wispr-flow:` deep links dropped (parse was win32-only) → widen the argv-parse guard | [`linux-deeplink.sh`](../../scripts/patches/linux-deeplink.sh) | `WISPR_LINUX_DEEPLINK` |
+| Fresh Linux profiles were **seeded** with macOS chords, so push-to-talk landed on keycode `-1` (no Linux key) — blank PTT in Settings, no way past the onboarding shortcuts step (#33, #46) → widen the win32 flag *inside the main bundle's shortcuts module only* | [`linux-main-shortcut-defaults.sh`](../../scripts/patches/linux-main-shortcut-defaults.sh) | `WISPR_LINUX_MAIN_SHORTCUT_DEFAULTS` |
 
 `linux-renderer-treat-as-windows.sh` is the high-leverage one: per renderer it
 widens the *one* place `isWindows` is bound into a module-local
@@ -178,6 +179,31 @@ help asset, plus a recording-start delay and a `voiceProfile` prop) where Linux
 correctly wants the Windows branch. The OS-API danger class lives in the **main**
 bundle and gates on `process.platform`/`H8`, which this renderer-only patch never
 touches.
+
+### The main bundle needed its own, narrower cut
+
+Being renderer-only is also this patch's blind spot. The default shortcut map
+lives in a module *shared* by both bundles, and the profile is written by the
+**main** process — where the same flag is `"win32"===process.platform`, i.e.
+false on Linux. So the renderer showed Windows chords while main persisted the
+macOS ones, and a fresh `config.json` came out as
+`"shortcuts":{"-1":"ptt","-1+32":"popo",...},"modifierShortcut":"9"`. Since `-1`
+is the "no keycode on this platform" sentinel, push-to-talk was literally
+unpressable: the key monitor delivered events that matched nothing, Settings
+rendered the binding blank, and onboarding could not be completed. That is the
+one bug behind both #33 and #46.
+
+The fix could **not** be "widen `H8` at its definition" — in the main bundle it
+has ~79 consumers and does gate the real Windows-only OS-API class (registry,
+`%LOCALAPPDATA%` path resolution, Windows exit-code semantics). So
+[`linux-main-shortcut-defaults.sh`](../../scripts/patches/linux-main-shortcut-defaults.sh)
+widens the flag only where it is *read inside the shortcuts module*. An audit of
+1.6.774 found the module reads it at **8** sites and every one selects a Windows
+chord against a macOS chord (default map, default modifier, four polish-prompt /
+meeting-recorder chord sets, two PTT-display accessors) — so all 8 are widened
+together, and the patch **fails closed** if any read there is ever not a ternary,
+rather than silently widening an OS gate. Fixing only the PTT default would have
+left its siblings seeding `-1` (e.g. `"-1+77"` for `open_meeting_recorder`).
 
 **Still gated out, deliberately deferred (known limits, not patched):**
 

--- a/nix/wispr-flow.nix
+++ b/nix/wispr-flow.nix
@@ -19,7 +19,7 @@
 }:
 let
   pname = "wispr-flow";
-  version = "1.6.7";
+  version = "1.6.774";
 
   #============================================================================
   # Source: the user-supplied Wispr Flow Windows installer (a Squirrel .exe).

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -277,6 +277,16 @@ step3_patch_bundle() {
     auto "Running linux-deeplink.sh on $target_bundle"
     bash "$SCRIPT_DIR/patches/linux-deeplink.sh" "$target_bundle" \
       || warn "Deep-link patch failed -- see linux-deeplink.sh output above."
+    # Seed fresh Linux profiles with the WINDOWS default shortcut/PTT map. The
+    # main process picks the defaults with a `"win32"===process.platform` flag,
+    # so on Linux it wrote the macOS map -- whose PTT key resolves to keycode -1
+    # ("no such key on Linux"). Result: an unpressable, blank push-to-talk
+    # binding and no way past the onboarding shortcuts step (issues #33, #46).
+    # Only the two default-seeding ternaries are widened; the flag's other ~79
+    # consumers (Windows-only OS/registry/path APIs) keep the real platform.
+    auto "Running linux-main-shortcut-defaults.sh on $target_bundle"
+    bash "$SCRIPT_DIR/patches/linux-main-shortcut-defaults.sh" "$target_bundle" \
+      || warn "Shortcut-defaults patch failed -- see linux-main-shortcut-defaults.sh output above."
 
     # Renderer + preload patches live alongside the main bundle under .webpack/.
     local webpack_root="${target_bundle%/main/index.js}"

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -185,6 +185,13 @@ if [[ -f "$ICON_SVG" ]]; then
 fi
 
 say "AppStream metadata"
+# NOTE: deliberately NO <icon> element. For a desktop-application component the
+# icon is resolved from the <launchable> .desktop file's Icon= key, so an
+# <icon type="stock"> here is redundant -- and appstream-glib's appstream-util
+# rejects it outright ("<icon> not allowed in desktop appdata"). appimagetool
+# runs whichever validators are installed, so declaring it broke the AppImage
+# build on hosts that have appstream-glib (e.g. Arch) while passing where only
+# the newer appstreamcli is present (e.g. the Ubuntu CI runners).
 cat > "$APPDIR/usr/share/metainfo/${COMPONENT_ID}.appdata.xml" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
@@ -201,7 +208,6 @@ cat > "$APPDIR/usr/share/metainfo/${COMPONENT_ID}.appdata.xml" <<EOF
     </p>
   </description>
   <launchable type="desktop-id">${COMPONENT_ID}.desktop</launchable>
-  <icon type="stock">${COMPONENT_ID}</icon>
   <url type="homepage">https://wisprflow.ai</url>
   <provides>
     <binary>AppRun</binary>

--- a/scripts/patches/helper-env.sh
+++ b/scripts/patches/helper-env.sh
@@ -8,12 +8,26 @@
 # WHY THIS PATCH EXISTS
 # ---------------------
 # The shipped main bundle spawns the native helper with a REPLACEMENT env
-# object that lists only telemetry keys -- it does NOT spread process.env:
+# object that lists only telemetry keys -- it does NOT spread process.env.
+# Up to 1.6.7 that object was inline at the spawn site:
 #
 #   helper.process = spawn(s, {
 #     stdio:["pipe","pipe","pipe","pipe"],
 #     env:{ sentryDSN, environment, segmentWriteKey,
 #           postHogProjectKey, sentryLocalDebug } })
+#
+# As of 1.6.774 upstream hoisted it into a factory, so the spawn site reads
+# `env:N()` and the object literal lives elsewhere in the module:
+#
+#   N = (packaged = app.isPackaged) => ({ sentryDSN, environment,
+#         segmentWriteKey, postHogProjectKey, sentryLocalDebug,
+#         developmentFileLogging })
+#   ... spawn(s, { stdio:["pipe","pipe","pipe","pipe"], env:N() })
+#
+# The env is still telemetry-only either way, so the bug is unchanged -- but an
+# anchor on the spawn site's `env:{` stopped matching and this patch silently
+# no-op'd (caught by verify-patches.sh, which fails the build on the missing
+# marker). We now anchor on the OBJECT rather than on where it is consumed.
 #
 # On macOS/Windows the helper talks to the OS through native APIs and needs no
 # session env, so upstream never spread process.env. But the Linux helper's
@@ -35,15 +49,19 @@
 #
 # THE PATCH (surgical, one insertion point)
 # -----------------------------------------
-# Anchor on the stable spawn literal (the 4-pipe stdio + the telemetry env
-# object -- both are preserved across minification because the stdio array and
-# the telemetry keys are string/property literals, not minified identifiers).
-# Insert a `...process.env,` spread at the FRONT of the env object so the
-# session env propagates, while the telemetry keys that follow still override
-# anything of the same name. On mac/win this only adds the (harmless) parent
-# env the helper already ignores, so the patch cannot regress those platforms.
+# Anchor on the telemetry env object's OWN opening -- `{sentryDSN:` -- rather
+# than on the spawn call that consumes it. Property names are not mangled by the
+# current bundler, so this survives re-minification AND survives the object
+# being hoisted, inlined, or wrapped in a factory: wherever the object is built,
+# that is where the spread belongs. `sentryDSN` appears exactly ONCE in the
+# whole bundle (asserted below), so the anchor cannot drift onto another object.
 #
-#   env:{...process.env,sentryDSN:...}   (marker comment carries the grep token)
+# Insert a `...process.env,` spread at the FRONT of the object so the session
+# env propagates, while the telemetry keys that follow still override anything of
+# the same name. On mac/win this only adds the (harmless) parent env the helper
+# already ignores, so the patch cannot regress those platforms.
+#
+#   {...process.env,sentryDSN:...}   (marker comment carries the grep token)
 #
 # stdio / fd-3 / exec-bit notes live in helper-resolver.sh PATCH NOTES.
 #===============================================================================
@@ -80,20 +98,33 @@ path, marker = sys.argv[1], sys.argv[2]
 with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
     data = f.read()
 
-# The helper spawn site: 4-pipe stdio (fd 3 = IPC channel) + the telemetry-only
-# replacement env. Unique in the bundle; if upstream ever spreads process.env
-# itself, the `...process.env` check below makes this a clean no-op.
-anchor = 'stdio:["pipe","pipe","pipe","pipe"],env:{'
+# The telemetry-only replacement env object handed to the helper spawn. Anchored
+# on its first property name (a preserved developer identifier), so it is found
+# whether the object sits inline at the spawn site (<=1.6.7) or inside a factory
+# the spawn calls (>=1.6.774). Asserted unique; if upstream ever spreads
+# process.env itself, the check below makes this a clean no-op.
+anchor = '{sentryDSN:'
 n = data.count(anchor)
 if n != 1:
-    sys.exit(f"ERROR: expected exactly 1 helper-spawn env anchor, found {n}.")
+    sys.exit(f"ERROR: expected exactly 1 telemetry env object anchor "
+             f"('{anchor}'), found {n}.")
+
+# Sanity-check the object really is the helper spawn's env: the 4-pipe stdio
+# spawn (fd 3 = the helper IPC channel) must exist too. Cheap, and it fails
+# closed if a future bundle reuses these property names for something else.
+if data.count('stdio:["pipe","pipe","pipe","pipe"]') != 1:
+    sys.exit('ERROR: expected exactly 1 four-pipe helper spawn site; '
+             'the bundle layout may have changed -- inspect manually.')
 
 after = data[data.find(anchor) + len(anchor):]
 if after.startswith("...process.env") or after.startswith(f"/*{marker}*/"):
     sys.exit(0)  # already spreads the parent env -- nothing to do
 
-# Insert the marker comment + spread at the front of the env object literal.
-repl = anchor + f"/*{marker}*/...process.env,"
+# Insert the marker comment + spread at the front of the env object literal --
+# i.e. just inside the `{`, BEFORE the property name the anchor also spans.
+# (Appending after the whole anchor would land inside the `sentryDSN:` value
+# position and produce `{sentryDSN:...process.env,`, a syntax error.)
+repl = "{" + f"/*{marker}*/" + "...process.env," + anchor[1:]
 data = data.replace(anchor, repl, 1)
 
 with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
@@ -122,5 +153,5 @@ fi
 echo "OK: helper-spawn env now inherits the session environment in $BUNDLE"
 echo
 echo "Patched spawn now does (conceptually):"
-echo "  spawn(helper, { stdio:[...x4],"
-echo "    env:{ ...process.env, sentryDSN, environment, ... } });"
+echo "  env object := { ...process.env, sentryDSN, environment, ... }"
+echo "  spawn(helper, { stdio:[...x4], env: <that object> });"

--- a/scripts/patches/linux-main-shortcut-defaults.sh
+++ b/scripts/patches/linux-main-shortcut-defaults.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+#===============================================================================
+# linux-main-shortcut-defaults.sh
+#
+# Makes the Wispr Flow MAIN bundle (.webpack/main/index.js) pick WINDOWS
+# keyboard chords instead of macOS ones inside its shortcuts module, so Linux
+# profiles are seeded with shortcuts that have actual Linux keycodes.
+#
+# THE BUG  (upstream issues #33 and #46)
+# --------------------------------------
+# A fresh Linux profile is created with push-to-talk bound to a key that does
+# not exist on Linux, so dictation can never be triggered and the onboarding
+# "Shortcuts" step can never be satisfied. A brand-new
+# ~/.config/Wispr Flow/config.json on 1.6.774 contained:
+#
+#   "shortcuts": { "27":"dismiss", "-1":"ptt", "-1+32":"popo",
+#                  "-1+162":"lens", "-1+162+86":"paste_last_text",
+#                  "-1+162+67":"copy_last_text", "-1+77":"open_meeting_recorder" },
+#   "modifierShortcut": "9"
+#
+# `-1` is the documented sentinel for "this key has no keycode on Linux" (see
+# docs/reference/keycodes.json: opt/opt_r/cmd/cmd_r/fn/doubleFn are all -1 on
+# linux). So those entries are unpressable, Settings renders the binding BLANK,
+# and the helper's key monitor delivers events that match nothing. Symptoms:
+#   * issue #46 -- stuck on the onboarding shortcuts screen: the shown shortcut
+#     does nothing and re-recording it appears to do nothing
+#   * issue #33 -- dictation silently untriggerable, blank PTT in Settings
+#
+# WHY THE RENDERER PATCH DOES NOT COVER THIS
+# ------------------------------------------
+# The chords live in a module shared by the main and renderer bundles, which
+# picks between a Windows and a macOS set with a single platform flag:
+#
+#   <winMap> = { [ctrl+win]:Ptt, [ctrl+win+space]:Popo, ... }   // Windows
+#   <macMap> = { [fn]:Ptt,       [fn+space]:Popo,       ... }   // macOS
+#   defaultShortcuts = <flag> ? <winMap> : <macMap>
+#
+# In the RENDERER `<flag>` derives from the bridged `platform.isWindows`, which
+# linux-renderer-treat-as-windows.sh already widens to include linux. But the
+# profile is seeded by the MAIN process, where the same `<flag>` is
+# `"win32"===process.platform` -- false on Linux -- so main takes the macOS
+# branch and writes the `-1` map to config.json. Patching only the renderer
+# fixes the labels you see, never the values you get.
+#
+# WHY NOT WIDEN THE MAIN `isWindows` FLAG AT ITS SOURCE
+# -----------------------------------------------------
+# Because in the main bundle that flag has ~79 consumers across the app and it
+# gates the genuinely Windows-only OS-API class -- registry access,
+# %LOCALAPPDATA%-style path resolution, Windows-specific process/exit-code
+# semantics. Flipping it at its definition is exactly the danger
+# docs/learnings/platform-gates.md warns about ("the OS-API danger class lives
+# in the MAIN bundle and gates on process.platform"). So we widen the flag ONLY
+# where it is read INSIDE the shortcuts module, and leave every other consumer
+# reporting the real platform.
+#
+# THE FIX (every chord consumer in that module, not just the PTT default)
+# ----------------------------------------------------------------------
+# Within the shortcuts module only, each read of the flag becomes:
+#
+#   <flag>            ->   (<flag>||"linux"===process.platform)
+#
+# In 1.6.774 that module reads the flag at 8 sites, and ALL EIGHT select a
+# Windows chord against a macOS chord -- the default shortcut map, the default
+# modifier, the four polish-prompt / meeting-recorder chord sets, and the two
+# accessors that resolve the PTT chord for display. Fixing only the PTT default
+# would leave its siblings seeding `-1` (e.g. "-1+77" open_meeting_recorder), so
+# the flag is widened for the whole module in one rule.
+#
+# Linux then seeds the documented Linux chord: PTT = Ctrl+Meta, stored as
+# "162+91" (left Ctrl 162, left Meta/Win 91 -- see
+# docs/learnings/global-key-monitor.md), and modifier = Alt (164) not Tab (9).
+# macOS and Windows are untouched: on darwin the flag is false and the platform
+# check is false, so darwin still gets <macMap>; on win32 the flag is already
+# true. The module's separate isMac flag is NOT touched (it already yields the
+# correct Ctrl-side chords on Linux).
+#
+# ANCHORING (survives re-minification, fails closed)
+# --------------------------------------------------
+# Every identifier is minified and churns between builds, so NONE is hardcoded.
+# The module is located by its PRESERVED developer names -- the keycode-table
+# properties `ctrl`/`win`/`space` and `fn`/`space`, and the command-enum members
+# `Ptt`/`Popo` -- and the flag is read back out of the ternary that selects
+# between those two maps. Two invariants must hold or the patch aborts without
+# editing:
+#   1. exactly one Windows map and one macOS map in the bundle, in one module;
+#   2. EVERY read of the flag inside that module is immediately followed by `?`
+#      (i.e. every use is a ternary selection, never an OS-API branch).
+# If upstream ever reads the flag non-ternarily in this module, (2) trips and a
+# human re-audits instead of the patch silently widening an OS gate.
+#
+# Usage: linux-main-shortcut-defaults.sh <path-to-.webpack/main/index.js>
+#===============================================================================
+set -euo pipefail
+
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+  BUNDLE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  BUNDLE="${BUNDLE%/scripts}"
+  BUNDLE="$BUNDLE/extract/app/.webpack/main/index.js"
+fi
+
+if [[ ! -f "$BUNDLE" ]]; then
+  echo "ERROR: bundle not found: $BUNDLE" >&2
+  exit 1
+fi
+
+MARKER="WISPR_LINUX_MAIN_SHORTCUT_DEFAULTS"
+if grep -q "$MARKER" "$BUNDLE"; then
+  echo "Already patched ($MARKER present in $BUNDLE) - nothing to do."
+  exit 0
+fi
+
+if [[ ! -f "$BUNDLE.orig" ]]; then
+  cp -p "$BUNDLE" "$BUNDLE.orig"
+  echo "Backup written: $BUNDLE.orig"
+fi
+
+python3 - "$BUNDLE" "$MARKER" <<'PY'
+import sys, io, re
+
+path, marker = sys.argv[1], sys.argv[2]
+with io.open(path, "r", encoding="utf-8", errors="surrogateescape") as f:
+    data = f.read()
+
+def only(pattern, what, hay=None):
+    hay = data if hay is None else hay
+    ms = list(re.finditer(pattern, hay))
+    if len(ms) != 1:
+        sys.exit(f"ERROR: expected exactly 1 {what}, found {len(ms)}. "
+                 f"The bundle layout may have changed; inspect manually.")
+    return ms[0]
+
+# --- 1. the WINDOWS chord map: its Popo key is the ctrl+win+space chord -------
+# <winMap>={[<x>]:<enum>.Ptt,[<O>([<keys>.ctrl,<keys>.win,<keys>.space])]:<enum>.Popo,
+win = only(
+    r'(?P<map>[\w$]+)=\{\[[\w$]+\]:(?P<enum>[\w$]+)\.Ptt,'
+    r'\[(?P<O>[\w$]+)\(\[(?P<keys>[\w$]+)\.ctrl,\4\.win,\4\.space\]\)\]:\2\.Popo,',
+    "Windows chord map (ctrl+win+space Popo)")
+win_map, enum_obj, chord_fn, keys_obj = (
+    win.group('map'), win.group('enum'), win.group('O'), win.group('keys'))
+
+# --- 2. the macOS chord map: its Popo key is the fn+space chord --------------
+mac = only(
+    r'(?P<map>[\w$]+)=\{\[[\w$]+\]:%s\.Ptt,\[%s\(\[%s\.fn,%s\.space\]\)\]:%s\.Popo,'
+    % tuple(map(re.escape, (enum_obj, chord_fn, keys_obj, keys_obj, enum_obj))),
+    "macOS chord map (fn+space Popo)")
+mac_map = mac.group('map')
+
+# --- 3. the ternary selecting between them -> read the platform flag back out -
+sel = only(r'(?P<flag>[\w$]+(?:\.[\w$]+)?)\?%s:%s'
+           % (re.escape(win_map), re.escape(mac_map)),
+           "winMap/macMap selecting ternary")
+flag = sel.group('flag')
+if '"linux"' in flag:
+    sys.exit(0)   # already accounts for linux
+
+# --- 4. bound the enclosing webpack module -----------------------------------
+# Module bodies look like `,<id>(e,t,n){"use strict";...`. Walk back to the
+# header that precedes both maps, and forward to the next module header.
+hdr = re.compile(r',(\d{3,6})\(e,t,n\)\{"use strict";')
+lo = max(m.start() for m in hdr.finditer(data, 0, min(win.start(), mac.start(), sel.start())))
+nxt = hdr.search(data, max(win.end(), mac.end(), sel.end()))
+hi = nxt.start() if nxt else len(data)
+mod_id = hdr.match(data, lo).group(1)
+body = data[lo:hi]
+
+# Both maps and the selector must live in this one module.
+for pos, what in ((win.start(), "Windows map"), (mac.start(), "macOS map"),
+                  (sel.start(), "selector")):
+    if not (lo <= pos < hi):
+        sys.exit(f"ERROR: {what} lies outside the resolved module extent.")
+
+# --- 5. INVARIANT: every flag read in this module is a ternary selection ------
+# Left boundary matters: a bare `r.H8` string also occurs inside longer
+# identifiers such as `lr.H8` (a DIFFERENT module-local elsewhere in the
+# bundle), so require the flag not be preceded by an identifier or dot char.
+flag_re = re.compile(r'(?<![\w$.])' + re.escape(flag) + r'(?![\w$])')
+uses = list(flag_re.finditer(body))
+if not uses:
+    sys.exit(f"ERROR: flag {flag!r} not found inside module {mod_id}.")
+non_ternary = [u for u in uses if not body[u.end():u.end() + 1] == '?']
+if non_ternary:
+    ctx = body[max(0, non_ternary[0].start() - 90):non_ternary[0].end() + 90]
+    sys.exit(
+        f"ERROR: {len(non_ternary)} of {len(uses)} reads of {flag!r} in module "
+        f"{mod_id} are NOT ternary selections. Refusing to widen a possible "
+        f"OS-API gate. First one: ...{ctx}...")
+
+# --- 6. widen every read, inside this module only ----------------------------
+widened = f'({flag}||"linux"===process.platform)'
+new_body, n = flag_re.subn(lambda m: widened, body)
+if n != len(uses):
+    sys.exit(f"ERROR: widened {n} sites, expected {len(uses)}.")
+
+# Marker on the first widened site (the grep token verify-patches.sh looks for).
+first = new_body.find(widened) + len(widened)
+new_body = new_body[:first] + f'/*{marker}*/' + new_body[first:]
+
+data = data[:lo] + new_body + data[hi:]
+with io.open(path, "w", encoding="utf-8", errors="surrogateescape") as f:
+    f.write(data)
+
+print(f"Patched module {mod_id}: flag={flag!r} widened at {len(uses)} chord-"
+      f"selection site(s); winMap={win_map} macMap={mac_map}.")
+PY
+
+if ! grep -q "$MARKER" "$BUNDLE"; then
+  echo "ERROR: post-patch verification failed (marker not found). Restoring." >&2
+  cp -p "$BUNDLE.orig" "$BUNDLE"
+  exit 1
+fi
+
+if ! grep -qF '||"linux"===process.platform)/*'"$MARKER"'*/?' "$BUNDLE"; then
+  echo "ERROR: widened flag not in expected form. Restoring." >&2
+  cp -p "$BUNDLE.orig" "$BUNDLE"
+  exit 1
+fi
+
+if command -v node >/dev/null; then
+  if ! node --check "$BUNDLE"; then
+    echo "ERROR: node --check failed on patched bundle. Restoring." >&2
+    cp -p "$BUNDLE.orig" "$BUNDLE"
+    exit 1
+  fi
+  echo "node --check OK"
+fi
+
+echo "OK: Linux now picks the Windows chords in the shortcuts module of $BUNDLE"
+echo
+echo "Effect on a FRESH Linux profile (config.json):"
+echo '  ptt                   "-1"        ->  "162+91"      (Ctrl+Meta)'
+echo '  popo                  "-1+32"     ->  "162+32+91"   (Ctrl+Meta+Space)'
+echo '  lens                  "-1+162"    ->  "162+164+91"  (Ctrl+Alt+Meta)'
+echo '  paste_last_text       "-1+162+86" ->  "160+164+90"  (Shift+Alt+Z)'
+echo '  copy_last_text        "-1+162+67" ->  "160+164+88"  (Shift+Alt+X)'
+echo '  open_meeting_recorder "-1+77"     ->  "91+164+77"   (Meta+Alt+M)'
+echo '  modifierShortcut      "9" (Tab)   ->  "164"         (Alt)'
+echo "  macOS/Windows profiles are unchanged."

--- a/scripts/setup/download.sh
+++ b/scripts/setup/download.sh
@@ -45,8 +45,14 @@ _fetch() {
 #   * --exe absent (default): resolve the latest upstream URL and download it
 #     (see fetch_installer). The proprietary app is never bundled or committed
 #     to the repo -- it is fetched/supplied fresh each build.
-# A SHA-256 is verified IF one is known (WISPR_EXE_SHA256 env or installer.sha256
-# file). Upstream publishes no stable hash, so absence only warns.
+# A SHA-256 is verified IF one is known, in precedence order:
+#   1. WISPR_EXE_SHA256 env      (explicit operator override, wins over all)
+#   2. installer.sha256 file     (pinned in-tree)
+#   3. the upstream release manifest's own sha256, captured by fetch_installer
+#      (resolve-installer-url.sh emits SHA256=; only set on the fetch path, so
+#      a --exe installer is never checked against the *latest* hash)
+# Absence still only warns -- but on the default fetch path a hash is now always
+# available, so a corrupted or tampered download fails the build.
 #-------------------------------------------------------------------------------
 download_installer() {
 	say 'Locate Wispr Flow installer'
@@ -59,12 +65,14 @@ download_installer() {
 		fetch_installer
 	fi
 
-	# Optional SHA-256 verification.
+	# Optional SHA-256 verification (see precedence in the header comment).
 	local expected_sha=''
 	if [[ -n ${WISPR_EXE_SHA256:-} ]]; then
 		expected_sha="$WISPR_EXE_SHA256"
 	elif [[ -f "$project_root/installer.sha256" ]]; then
 		expected_sha=$(awk '{print $1; exit}' "$project_root/installer.sha256")
+	elif [[ -n ${resolved_installer_sha256:-} ]]; then
+		expected_sha="$resolved_installer_sha256"
 	fi
 	verify_sha256 "$installer_exe_path" "$expected_sha" 'Wispr Flow installer' \
 		|| die 'Installer checksum verification failed'
@@ -84,12 +92,19 @@ fetch_installer() {
 	[[ -x $resolver ]] || die "installer resolver not found: $resolver"
 
 	auto 'No --exe supplied; resolving the latest Wispr Flow installer'
-	local resolved url version
+	local resolved url version sha
 	resolved=$("$resolver") \
 		|| die 'Failed to resolve the Wispr Flow installer URL (pass --exe to use a local installer)'
 	url=$(printf '%s\n' "$resolved" | sed -nE 's/^URL=//p')
 	version=$(printf '%s\n' "$resolved" | sed -nE 's/^VERSION=//p')
+	sha=$(printf '%s\n' "$resolved" | sed -nE 's/^SHA256=//p')
 	[[ -n $url ]] || die 'installer resolver returned no URL'
+	# Publish the manifest hash for download_installer's verification step. Only
+	# the fetch path sets it, so a local --exe is never judged against it.
+	resolved_installer_sha256="$sha"
+	if [[ -z $sha ]]; then
+		warn 'upstream manifest published no sha256; the download cannot be verified'
+	fi
 
 	if [[ -n $version && $version != "${APP_VERSION:-}" ]]; then
 		die "upstream latest is ${version} but this build is pinned to ${APP_VERSION}.

--- a/scripts/setup/resolve-installer-url.sh
+++ b/scripts/setup/resolve-installer-url.sh
@@ -1,31 +1,48 @@
 #!/usr/bin/env bash
 #===============================================================================
 # resolve-installer-url.sh -- resolve the latest Wispr Flow Windows installer
-# download URL and version from the upstream "latest" redirect.
+# download URL, version and SHA-256 from the upstream release manifest.
 #
-# Wispr Flow publishes a stable redirect endpoint that 302s to a versioned,
-# CDN-hosted Setup .exe whose filename embeds the version:
+# WHY A MANIFEST AND NOT THE "latest" REDIRECT
+# --------------------------------------------
+# Until ~2026-08-05 the stable redirect endpoint
 #   https://dl.wisprflow.ai/windows/latest
-#     -> https://dl.wisprflow.com/wispr-flow/win32/x64/Wispr%20Flow%20Setup-v1.5.695.exe
+# 302'd straight to a versioned, full Squirrel installer whose filename embedded
+# the version:
+#   -> .../win32/x64/Wispr%20Flow%20Setup-v1.5.695.exe
+# Upstream then repointed that redirect at a ~6 MB .NET *web-bootstrap stub*:
+#   -> .../win32/x64/WisprFlowInstaller.exe
+# The stub is useless to this build for two independent reasons: its filename
+# carries no version (so the old sed parse yields nothing and this script died),
+# and it embeds no payload at all -- no `*-full.nupkg`, so no `app.asar` for
+# extract_installer() to unpack. It only downloads the real installer at run
+# time, resolving it through the JSON manifest the stub itself ships:
+#   https://dl.wisprflow.com/wispr-flow/win32/latest.json
+#   {"schemaVersion":1,"windows":{"x64":{"url":..., "sha256":..., "size":...}}}
+# So we read the same manifest the stub reads. That URL still points at the
+# versioned full Squirrel installer (filename version parse unchanged), and the
+# manifest additionally publishes a **SHA-256**, which the redirect never did --
+# so a fetched proprietary binary is now checksum-verifiable (see download.sh).
 #
-# Only a Windows x64 build is published (the arm64 Windows endpoint redirects to
-# the homepage). The Linux arm64 package is built from the SAME x64 installer --
-# the app bundle is arch-neutral JS/asar -- so this resolver is arch-independent.
+# A `last-known-good.json` sits alongside `latest.json` with the same schema;
+# --latest-url points this script at either one.
 #
 # Output contract (stdout, one KEY=VALUE per line; ALL diagnostics to stderr):
-#   URL=<final resolved download URL>
+#   URL=<versioned full-installer download URL>
 #   VERSION=<x.y.z extracted from the installer filename>
+#   SHA256=<hex digest from the manifest, or empty if the manifest omits it>
+# SHA256 is emitted LAST and may be absent; parse by key, never by line number.
 #
 # Usage:   resolve-installer-url.sh [--latest-url <url>] [--version <x.y.z>]
-#   --latest-url   override the upstream "latest" redirect endpoint
+#   --latest-url   override the upstream manifest URL (e.g. last-known-good.json)
 #   --version      skip filename parsing and emit this version verbatim
 #
-# Exit 0 on success; non-zero if the URL can't be resolved or the version can't
-# be parsed. This is a standalone CI helper -- it sources nothing.
+# Exit 0 on success; non-zero if the manifest can't be fetched/parsed or the
+# version can't be determined. Standalone CI helper -- it sources nothing.
 #===============================================================================
 set -uo pipefail
 
-readonly DEFAULT_LATEST_URL='https://dl.wisprflow.ai/windows/latest'
+readonly DEFAULT_LATEST_URL='https://dl.wisprflow.com/wispr-flow/win32/latest.json'
 
 log() { printf '%s\n' "$*" >&2; }
 die() { printf 'resolve-installer-url: %s\n' "$*" >&2; exit 1; }
@@ -49,25 +66,54 @@ while [[ $# -gt 0 ]]; do
 done
 
 command -v curl >/dev/null 2>&1 || die 'curl is required'
+command -v python3 >/dev/null 2>&1 || die 'python3 is required (manifest is JSON)'
 
 log "Resolving Wispr Flow installer from ${latest_url} ..."
 
-# Follow the redirect chain with a HEAD request and report the final URL.
-# -f fails on HTTP errors; -S surfaces them; -L follows redirects; -I = HEAD.
-final_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
-	--max-time 60 "$latest_url")"
+manifest="$(curl -fsSL --max-time 60 "$latest_url")"
 rc=$?
-if [[ $rc -ne 0 || -z $final_url ]]; then
-	die "failed to resolve ${latest_url} (curl rc=${rc})"
+if [[ $rc -ne 0 || -z $manifest ]]; then
+	die "failed to fetch ${latest_url} (curl rc=${rc})"
 fi
 
-if [[ $final_url == "$latest_url" ]]; then
-	die "no redirect followed from ${latest_url} (got the same URL back)"
-fi
+# Pull url + sha256 out of windows.x64. Only a Windows x64 build is published;
+# the Linux arm64 package is built from the SAME x64 installer (the app bundle
+# is arch-neutral JS/asar), so this resolver stays arch-independent.
+# Emits "<url>\t<sha256>"; a missing/!=1 schemaVersion only warns (the shape is
+# validated by the keys we actually read, not by the version number).
+parsed="$(printf '%s' "$manifest" | python3 -c '
+import json, sys
+try:
+    m = json.load(sys.stdin)
+except Exception as e:
+    sys.exit(f"manifest is not valid JSON: {e}")
+sv = m.get("schemaVersion")
+if sv != 1:
+    print(f"warning: unexpected manifest schemaVersion {sv!r} (expected 1)", file=sys.stderr)
+try:
+    entry = m["windows"]["x64"]
+except (KeyError, TypeError):
+    sys.exit("manifest has no windows.x64 entry")
+url = (entry.get("url") or "").strip()
+if not url:
+    sys.exit("manifest windows.x64 entry has no url")
+if not url.startswith("https://"):
+    sys.exit(f"refusing non-https installer url: {url}")
+sha = (entry.get("sha256") or "").strip().lower()
+if sha and (len(sha) != 64 or any(c not in "0123456789abcdef" for c in sha)):
+    sys.exit(f"manifest sha256 is not a 64-hex digest: {sha!r}")
+print(f"{url}\t{sha}")
+')"
+rc=$?
+[[ $rc -eq 0 && -n $parsed ]] || die "could not parse ${latest_url}"
+
+final_url="${parsed%%$'\t'*}"
+sha256="${parsed#*$'\t'}"
 
 log "Resolved URL: ${final_url}"
 
-# Extract the version from the filename, e.g. "...Setup-v1.5.695.exe" -> 1.5.695.
+# Extract the version from the filename, e.g. "...Setup-v1.6.774.exe" -> 1.6.774.
+# Works on the percent-encoded URL as-is (the space is %20, the version isn't).
 if [[ -n $version_override ]]; then
 	version="$version_override"
 else
@@ -80,6 +126,12 @@ if [[ -z $version ]]; then
 fi
 
 log "Resolved version: ${version}"
+if [[ -n $sha256 ]]; then
+	log "Resolved sha256:  ${sha256}"
+else
+	log 'Manifest published no sha256 for this entry.'
+fi
 
 printf 'URL=%s\n' "$final_url"
 printf 'VERSION=%s\n' "$version"
+printf 'SHA256=%s\n' "$sha256"

--- a/scripts/verify-patches.sh
+++ b/scripts/verify-patches.sh
@@ -11,6 +11,9 @@
 #     * mac-gates.sh           -> gates the macOS Applications-folder guard
 #     * linux-window-frame.sh  -> frameless hub/settings window on Linux
 #     * linux-deeplink.sh      -> cold-start wispr-flow: argv parse on Linux
+#     * linux-main-shortcut-defaults.sh -> Linux profiles seed the Windows
+#       default shortcut/push-to-talk map instead of the macOS one (whose
+#       PTT key has no Linux keycode)
 #   renderer bundles:
 #     * linux-renderer-chrome.sh -> remaps the <html> platform class linux->win32
 #     * linux-renderer-treat-as-windows.sh -> widens each renderer's isWindows
@@ -48,6 +51,7 @@ MARKERS=(
   "window-frame: linux frameless window branch|F|WISPR_LINUX_FRAMELESS"
   "treat-as-windows: linux widens renderer isWindows bind|F|WISPR_LINUX_RENDERER_ISWIN"
   "deeplink: linux cold-start argv parse|F|WISPR_LINUX_DEEPLINK"
+  "shortcut-defaults: linux seeds the Windows PTT map|F|WISPR_LINUX_MAIN_SHORTCUT_DEFAULTS"
 )
 
 missing=0

--- a/tests/verify-patches.bats
+++ b/tests/verify-patches.bats
@@ -6,7 +6,7 @@
 # (the .asar stores the JS bundle as concatenated plaintext, so a byte-grep
 # finds the markers without unpacking).
 #
-# verify-patches.sh greps a fixed set of markers (8 fixed strings + 1 Perl
+# verify-patches.sh greps a fixed set of markers (9 fixed strings + 1 Perl
 # regex). We build a tiny fixture carrying those exact marker strings (PASS)
 # and per-marker fixtures that omit one (FAIL).
 #
@@ -37,6 +37,7 @@ declare -gA MARKER_SAMPLES=(
 	[windowframe]='"win32"===process.platform||"linux"===process.platform/*WISPR_LINUX_FRAMELESS*/&&Object.assign(t,{titleBarStyle:"hidden"});'
 	[treataswindows]='const x=((y?.platform?.isWindows??!1)||"linux"===y?.platform?.os)/*WISPR_LINUX_RENDERER_ISWIN*/;'
 	[deeplink]='if(f.H8||"linux"===process.platform){/*WISPR_LINUX_DEEPLINK*/const e=process.argv.find(x=>x.startsWith("wispr-flow:"));}'
+	[shortcutdefaults]='const d=(r.H8||"linux"===process.platform)/*WISPR_LINUX_MAIN_SHORTCUT_DEFAULTS*/?re:Ie,m=(r.H8||"linux"===process.platform)?ae:Te;'
 )
 
 # Write a fixture app.asar-like file containing every marker, except the one
@@ -149,6 +150,14 @@ write_fixture() {
 @test "verify: exits 1 when the deeplink marker is missing" {
 	local fixture
 	fixture="$(write_fixture deeplink)"
+	run "$VERIFY_SH" "$fixture"
+	[[ "$status" -eq 1 ]]
+	[[ "$output" == *'MISSING'* ]]
+}
+
+@test "verify: exits 1 when the shortcut-defaults marker is missing" {
+	local fixture
+	fixture="$(write_fixture shortcutdefaults)"
 	run "$VERIFY_SH" "$fixture"
 	[[ "$status" -eq 1 ]]
 	[[ "$output" == *'MISSING'* ]]


### PR DESCRIPTION
Four fixes found while getting a build working on Arch/Wayland. They are
independent — happy to split if you'd rather take them separately — but the
build is broken end to end without the first, so they were developed together.

### 1. `fix(patches)`: seed Linux profiles with the Windows shortcut map (#33, #46)

Root cause behind both #33 and #46. A fresh Linux profile is seeded with
`-1` keycodes — the documented "no keycode on this platform" sentinel
(`docs/reference/keycodes.json`):

```json
"shortcuts": { "-1":"ptt", "-1+32":"popo", "-1+162":"lens", "-1+77":"open_meeting_recorder", ... },
"modifierShortcut": "9"
```

So push-to-talk is unpressable, Settings renders it blank, and onboarding's
"Shortcuts" step can never be satisfied.

`linux-renderer-treat-as-windows.sh` already widens the platform flag in the
renderer — but the profile is seeded by the **main** process, where the flag is
`"win32"===process.platform`. The renderer showed Windows chords while main
persisted the macOS ones.

The flag has ~79 consumers in the main bundle and does gate the real
Windows-only OS-API class (registry, `%LOCALAPPDATA%`, exit-code semantics), so
it is widened only where read *inside* the shortcuts module — all 8 reads
there, each selecting a Windows chord against a macOS one. Fixing only the PTT
default would leave siblings seeding `-1`. The patch fails closed if any read
is ever not a ternary, and anchors solely on preserved developer names.

Verified on a fresh profile: ptt `162+91` (Ctrl+Meta), modifierShortcut `164`
(Alt), zero `-1` entries.

### 2. `fix(patches)`: re-anchor helper-env on the telemetry env object

1.6.774 hoisted the helper-spawn env out of the spawn call into a factory, so
the `stdio:[...],env:{` anchor stopped matching and the patch became a **silent
no-op**. Without the session env (`WAYLAND_DISPLAY` / `DISPLAY` /
`XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS`) the helper falls through to the
no-op `stub` backend and nothing is typed into the focused app.

Now anchors on the object itself (`{sentryDSN:`, unique in the bundle), so it
matches whether the literal is inline (≤1.6.7) or inside a factory (≥1.6.774).
The 4-pipe spawn site is still asserted so it fails closed.

Verified against both bundle shapes; 1.6.774 now reports
`injection: Wayland (uinput + wl-clipboard)` instead of `stub`.

### 3. `feat(build)`: resolve the installer from upstream's JSON manifest; bump to 1.6.774

Around 2026-08-05 Wispr repointed the `latest` redirect this build relies on:

```
https://dl.wisprflow.ai/windows/latest
  was  -> .../Wispr%20Flow%20Setup-v1.5.695.exe   (full installer)
  now  -> .../WisprFlowInstaller.exe              (~6 MB .NET stub)
```

The stub's filename carries no version (the sed parse in
`resolve-installer-url.sh` yields nothing and the script dies) and embeds no
`*-full.nupkg`, so there is no app.asar to unpack. That is why the pin has been
stuck at 1.6.7 since 2026-07-11.

Resolves from the same manifest the stub itself reads
(`.../win32/latest.json`), whose URL still points at the versioned full
Squirrel installer. It also publishes a SHA-256 — which the redirect never did
— so `download.sh` now verifies the fetched binary. Precedence:
`WISPR_EXE_SHA256` > `installer.sha256` > manifest; only the fetch path sets
it, so a local `--exe` is never judged against the *latest* hash.

Pin bumped to 1.6.774.

### 4. `fix(packaging)`: drop the `<icon>` element appstream-util rejects

On a host with appstream-glib installed (e.g. Arch), appimagetool fails:

```
• tag-invalid : <icon> not allowed in desktop appdata
• tag-invalid : stock icon is not valid [ai.wisprflow.WisprFlow]
ERROR: appimagetool failed to build the AppImage
```

Redundant anyway — for a desktop-application component the icon resolves from
the `<launchable>` .desktop `Icon=` key. The Ubuntu CI runners don't have
appstream-glib, so this never showed up in CI.

---

**Testing:** verified end to end on Arch/Wayland (Hyprland) — manifest resolve,
checksum match, all 10 Linux patch markers present in the repacked asar, and
88/88 bats tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
